### PR TITLE
Remove the bidi Connect

### DIFF
--- a/examples/docker_agent/main.go
+++ b/examples/docker_agent/main.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"os"
@@ -39,16 +38,8 @@ type server struct {
 	skillsExecutor *skills.Executor
 }
 
-func (s *server) Connect(stream grpc.BidiStreamingServer[proto.AgentMessage, proto.AgentMessage]) error {
-	incoming, err := stream.Recv()
-	if err == io.EOF {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-
-	start := incoming.GetStart()
+func (s *server) Connect(req *proto.AgentRequest, stream grpc.ServerStreamingServer[proto.AgentResponse]) error {
+	start := req.GetStart()
 	if start == nil {
 		return errors.New("missing start message")
 	}
@@ -131,10 +122,10 @@ func (s *server) Connect(stream grpc.BidiStreamingServer[proto.AgentMessage, pro
 						},
 					},
 				}
-				if err := stream.Send(&proto.AgentMessage{
-					ConversationId: incoming.ConversationId,
-					ExecId:         incoming.ExecId,
-					Type: &proto.AgentMessage_Outputs{
+				if err := stream.Send(&proto.AgentResponse{
+					ConversationId: req.ConversationId,
+					ExecId:         req.ExecId,
+					Type: &proto.AgentResponse_Outputs{
 						Outputs: &proto.AgentOutputs{
 							Messages: []*proto.Message{responseMsg},
 						},
@@ -153,10 +144,10 @@ func (s *server) Connect(stream grpc.BidiStreamingServer[proto.AgentMessage, pro
 	fmt.Println("DockerAgent finished execution turn.")
 
 	// Send AgentEnd
-	return stream.Send(&proto.AgentMessage{
-		ConversationId: incoming.ConversationId,
-		ExecId:         incoming.ExecId,
-		Type: &proto.AgentMessage_End{
+	return stream.Send(&proto.AgentResponse{
+		ConversationId: req.ConversationId,
+		ExecId:         req.ExecId,
+		Type: &proto.AgentResponse_End{
 			End: &proto.AgentEnd{},
 		},
 	})

--- a/examples/docker_agent/test/test_docker_agent.go
+++ b/examples/docker_agent/test/test_docker_agent.go
@@ -34,34 +34,28 @@ func main() {
 	defer conn.Close()
 
 	client := proto.NewAgentServiceClient(conn)
-	stream, err := client.Connect(context.Background())
-	if err != nil {
-		log.Fatalf("Failed to open stream: %v", err)
-	}
-
 	fmt.Println("Sending request to write a Dockerfile...")
-	// Send start message
-	err = stream.Send(&proto.AgentMessage{
+	req := &proto.AgentRequest{
 		ConversationId: "test-conversation-id",
 		ExecId:         "test-exec-id",
-		Type: &proto.AgentMessage_Start{
-			Start: &proto.AgentStart{
-				AgentId: "DockerAgent",
-				Messages: []*proto.Message{
-					{
-						Role: "user",
-						Content: &proto.Content{
-							Type: &proto.Content_Text{
-								Text: &proto.TextContent{Text: "Write a Dockerfile for a simple Node.js app."},
-							},
+		Start: &proto.AgentStart{
+			AgentId: "DockerAgent",
+			Messages: []*proto.Message{
+				{
+					Role: "user",
+					Content: &proto.Content{
+						Type: &proto.Content_Text{
+							Text: &proto.TextContent{Text: "Write a Dockerfile for a simple Node.js app."},
 						},
 					},
 				},
 			},
 		},
-	})
+	}
+
+	stream, err := client.Connect(context.Background(), req)
 	if err != nil {
-		log.Fatalf("Failed to send message: %v", err)
+		log.Fatalf("Failed to open stream: %v", err)
 	}
 
 	fmt.Println("Waiting for response...")

--- a/examples/remote_agent/main.go
+++ b/examples/remote_agent/main.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"strings"
@@ -35,73 +34,64 @@ type server struct {
 	proto.UnimplementedAgentServiceServer
 }
 
-// Connect implements bidirectional streaming for agent processing.
-// This RPC is called by the gar controller when a session triggers this agent.
-func (s *server) Connect(stream grpc.BidiStreamingServer[proto.AgentMessage, proto.AgentMessage]) error {
-	for {
-		// Receive input content from gar controller
-		incoming, err := stream.Recv()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-
-		start := incoming.GetStart()
-		if start == nil {
-			continue // optionally wait for start
-		}
-
-		var messages []*proto.Message
-		for _, input := range start.Messages {
-			textContent := input.GetContent().GetText()
-			if textContent == nil {
-				continue
-			}
-			messages = append(messages, input)
-		}
-		if len(messages) == 0 {
-			return errors.New("no text inputs, cannot uppercase")
-		}
-
-		// We don't need to uppercase the whole history.
-		// Only uppercase the last text message.
-		lastMsg := messages[len(messages)-1]
-		responseMsg := &proto.Message{
-			Role: "assistant",
-			Content: &proto.Content{
-				Type: &proto.Content_Text{
-					Text: &proto.TextContent{
-						Text: strings.ToLower(lastMsg.GetContent().GetText().Text),
-					},
-				},
-			},
-		}
-
-		if err := stream.Send(&proto.AgentMessage{
-			ConversationId: incoming.ConversationId,
-			ExecId:         incoming.ExecId,
-			Type: &proto.AgentMessage_Outputs{
-				Outputs: &proto.AgentOutputs{
-					Messages: []*proto.Message{responseMsg},
-				},
-			},
-		}); err != nil {
-			return err
-		}
-
-		// Send AgentEnd to signal end of outputs.
-		if err := stream.Send(&proto.AgentMessage{
-			ConversationId: incoming.ConversationId,
-			ExecId:         incoming.ExecId,
-			Type: &proto.AgentMessage_End{
-				End: &proto.AgentEnd{},
-			},
-		}); err != nil {
-			return err
-		}
+// Connect implements server streaming for agent processing.
+// This RPC is called by the controller when a session triggers this agent.
+func (s *server) Connect(req *proto.AgentRequest, stream grpc.ServerStreamingServer[proto.AgentResponse]) error {
+	start := req.GetStart()
+	if start == nil {
+		return errors.New("start is required")
 	}
+
+	var messages []*proto.Message
+	for _, input := range start.Messages {
+		textContent := input.GetContent().GetText()
+		if textContent == nil {
+			continue
+		}
+		messages = append(messages, input)
+	}
+	if len(messages) == 0 {
+		return errors.New("no text inputs, cannot uppercase")
+	}
+
+	// We don't need to uppercase the whole history.
+	// Only uppercase the last text message.
+	lastMsg := messages[len(messages)-1]
+	responseMsg := &proto.Message{
+		Role: "assistant",
+		Content: &proto.Content{
+			Type: &proto.Content_Text{
+				Text: &proto.TextContent{
+					Text: strings.ToLower(lastMsg.GetContent().GetText().Text),
+				},
+			},
+		},
+	}
+
+	if err := stream.Send(&proto.AgentResponse{
+		ConversationId: req.ConversationId,
+		ExecId:         req.ExecId,
+		Type: &proto.AgentResponse_Outputs{
+			Outputs: &proto.AgentOutputs{
+				Messages: []*proto.Message{responseMsg},
+			},
+		},
+	}); err != nil {
+		return err
+	}
+
+	// Send AgentEnd to signal end of outputs.
+	if err := stream.Send(&proto.AgentResponse{
+		ConversationId: req.ConversationId,
+		ExecId:         req.ExecId,
+		Type: &proto.AgentResponse_End{
+			End: &proto.AgentEnd{},
+		},
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // HealthCheck checks if the agent is healthy.

--- a/internal/agent/remote.go
+++ b/internal/agent/remote.go
@@ -16,7 +16,6 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -75,24 +74,13 @@ func (a *RemoteAgent) Connect(ctx context.Context, conversationID string, execID
 	defer conn.Close()
 
 	client := proto.NewAgentServiceClient(conn)
-	stream, err := client.Connect(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create stream: %w", err)
-	}
-
-	if err := stream.Send(&proto.AgentMessage{
+	stream, err := client.Connect(ctx, &proto.AgentRequest{
 		ConversationId: conversationID,
 		ExecId:         execID,
-		Type: &proto.AgentMessage_Start{
-			Start: start,
-		},
-	}); err != nil {
-		return fmt.Errorf("failed to send content: %w", err)
-	}
-
-	// Close the send direction to signal we're done sending
-	if err := stream.CloseSend(); err != nil {
-		return fmt.Errorf("failed to close send: %w", err)
+		Start:          start,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create stream: %w", err)
 	}
 
 	// Receive outputs and call handler for each
@@ -107,9 +95,7 @@ func (a *RemoteAgent) Connect(ctx context.Context, conversationID string, execID
 		}
 
 		switch msg := resp.Type.(type) {
-		case *proto.AgentMessage_Start:
-			return errors.New("starting new executions from remote agents is not supported yet")
-		case *proto.AgentMessage_Outputs:
+		case *proto.AgentResponse_Outputs:
 			if resp.ConversationId != conversationID {
 				return fmt.Errorf("received outputs for different conversation id: %s != %s", resp.ConversationId, conversationID)
 			}
@@ -119,7 +105,7 @@ func (a *RemoteAgent) Connect(ctx context.Context, conversationID string, execID
 			if err := o(msg.Outputs); err != nil {
 				return fmt.Errorf("handler error: %w", err)
 			}
-		case *proto.AgentMessage_End:
+		case *proto.AgentResponse_End:
 			if resp.ConversationId != conversationID {
 				return fmt.Errorf("received end for different conversation id: %s != %s", resp.ConversationId, conversationID)
 			}

--- a/internal/agent/remote_test.go
+++ b/internal/agent/remote_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/google/ax/proto"
+)
+
+type mockAgentServiceServer struct {
+	proto.UnimplementedAgentServiceServer
+	mu       sync.Mutex
+	lastReq  *proto.AgentRequest
+	response []*proto.AgentResponse
+}
+
+func (s *mockAgentServiceServer) Connect(req *proto.AgentRequest, stream grpc.ServerStreamingServer[proto.AgentResponse]) error {
+	s.mu.Lock()
+	s.lastReq = req
+	s.mu.Unlock()
+
+	for _, resp := range s.response {
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestRemoteAgent_Connect(t *testing.T) {
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer lis.Close()
+
+	srv := grpc.NewServer()
+	defer srv.Stop()
+
+	mockServer := &mockAgentServiceServer{
+		response: []*proto.AgentResponse{
+			{
+				ConversationId: "conv-1",
+				ExecId:         "exec-1",
+				Type: &proto.AgentResponse_Outputs{
+					Outputs: &proto.AgentOutputs{
+						Messages: []*proto.Message{
+							{
+								Role: "assistant",
+								Content: &proto.Content{
+									Type: &proto.Content_Text{
+										Text: &proto.TextContent{Text: "Response line 1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ConversationId: "conv-1",
+				ExecId:         "exec-1",
+				Type: &proto.AgentResponse_End{
+					End: &proto.AgentEnd{},
+				},
+			},
+		},
+	}
+	proto.RegisterAgentServiceServer(srv, mockServer)
+
+	go func() {
+		if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+			t.Errorf("failed to serve: %v", err)
+		}
+	}()
+
+	addr := lis.Addr().String()
+	remoteAgent, err := NewRemoteAgent(RemoteAgentConfig{
+		Address: addr,
+		DialOpts: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create remote agent: %v", err)
+	}
+	defer remoteAgent.Close()
+
+	var outputs []*proto.AgentOutputs
+	outputHandler := func(outgoing *proto.AgentOutputs) error {
+		outputs = append(outputs, outgoing)
+		return nil
+	}
+
+	start := &proto.AgentStart{
+		AgentId: "test-agent",
+		Messages: []*proto.Message{
+			{
+				Role: "user",
+				Content: &proto.Content{
+					Type: &proto.Content_Text{
+						Text: &proto.TextContent{Text: "Request text"},
+					},
+				},
+			},
+		},
+	}
+
+	err = remoteAgent.Connect(context.Background(), "conv-1", "exec-1", start, nil, outputHandler)
+	if err != nil {
+		t.Fatalf("RemoteAgent.Connect failed: %v", err)
+	}
+
+	mockServer.mu.Lock()
+	lastReq := mockServer.lastReq
+	mockServer.mu.Unlock()
+
+	if lastReq == nil {
+		t.Fatal("server did not receive request")
+	}
+	if lastReq.ConversationId != "conv-1" {
+		t.Errorf("expected conversation ID 'conv-1', got %q", lastReq.ConversationId)
+	}
+	if lastReq.ExecId != "exec-1" {
+		t.Errorf("expected exec ID 'exec-1', got %q", lastReq.ExecId)
+	}
+	if lastReq.Start.AgentId != "test-agent" {
+		t.Errorf("expected agent ID 'test-agent', got %q", lastReq.Start.AgentId)
+	}
+
+	if len(outputs) != 1 {
+		t.Fatalf("expected exactly 1 output from handler, got %d", len(outputs))
+	}
+	if len(outputs[0].Messages) != 1 {
+		t.Fatalf("expected exactly 1 message in outputs, got %d", len(outputs[0].Messages))
+	}
+	gotText := outputs[0].Messages[0].GetContent().GetText().GetText()
+	if gotText != "Response line 1" {
+		t.Errorf("expected response text 'Response line 1', got %q", gotText)
+	}
+}

--- a/proto/ax.pb.go
+++ b/proto/ax.pb.go
@@ -229,34 +229,29 @@ func (*AgentEnd) Descriptor() ([]byte, []int) {
 	return file_proto_ax_proto_rawDescGZIP(), []int{2}
 }
 
-type AgentMessage struct {
+type AgentRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	ConversationId string                 `protobuf:"bytes,1,opt,name=conversation_id,json=conversationId,proto3" json:"conversation_id,omitempty"`
 	ExecId         string                 `protobuf:"bytes,2,opt,name=exec_id,json=execId,proto3" json:"exec_id,omitempty"`
-	// Types that are valid to be assigned to Type:
-	//
-	//	*AgentMessage_Start
-	//	*AgentMessage_Outputs
-	//	*AgentMessage_End
-	Type          isAgentMessage_Type `protobuf_oneof:"type"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Start          *AgentStart            `protobuf:"bytes,3,opt,name=start,proto3" json:"start,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
-func (x *AgentMessage) Reset() {
-	*x = AgentMessage{}
+func (x *AgentRequest) Reset() {
+	*x = AgentRequest{}
 	mi := &file_proto_ax_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *AgentMessage) String() string {
+func (x *AgentRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AgentMessage) ProtoMessage() {}
+func (*AgentRequest) ProtoMessage() {}
 
-func (x *AgentMessage) ProtoReflect() protoreflect.Message {
+func (x *AgentRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_ax_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -268,80 +263,129 @@ func (x *AgentMessage) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AgentMessage.ProtoReflect.Descriptor instead.
-func (*AgentMessage) Descriptor() ([]byte, []int) {
+// Deprecated: Use AgentRequest.ProtoReflect.Descriptor instead.
+func (*AgentRequest) Descriptor() ([]byte, []int) {
 	return file_proto_ax_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *AgentMessage) GetConversationId() string {
+func (x *AgentRequest) GetConversationId() string {
 	if x != nil {
 		return x.ConversationId
 	}
 	return ""
 }
 
-func (x *AgentMessage) GetExecId() string {
+func (x *AgentRequest) GetExecId() string {
 	if x != nil {
 		return x.ExecId
 	}
 	return ""
 }
 
-func (x *AgentMessage) GetType() isAgentMessage_Type {
+func (x *AgentRequest) GetStart() *AgentStart {
+	if x != nil {
+		return x.Start
+	}
+	return nil
+}
+
+type AgentResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	ConversationId string                 `protobuf:"bytes,1,opt,name=conversation_id,json=conversationId,proto3" json:"conversation_id,omitempty"`
+	ExecId         string                 `protobuf:"bytes,2,opt,name=exec_id,json=execId,proto3" json:"exec_id,omitempty"`
+	// Types that are valid to be assigned to Type:
+	//
+	//	*AgentResponse_Outputs
+	//	*AgentResponse_End
+	Type          isAgentResponse_Type `protobuf_oneof:"type"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AgentResponse) Reset() {
+	*x = AgentResponse{}
+	mi := &file_proto_ax_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AgentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AgentResponse) ProtoMessage() {}
+
+func (x *AgentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_ax_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AgentResponse.ProtoReflect.Descriptor instead.
+func (*AgentResponse) Descriptor() ([]byte, []int) {
+	return file_proto_ax_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *AgentResponse) GetConversationId() string {
+	if x != nil {
+		return x.ConversationId
+	}
+	return ""
+}
+
+func (x *AgentResponse) GetExecId() string {
+	if x != nil {
+		return x.ExecId
+	}
+	return ""
+}
+
+func (x *AgentResponse) GetType() isAgentResponse_Type {
 	if x != nil {
 		return x.Type
 	}
 	return nil
 }
 
-func (x *AgentMessage) GetStart() *AgentStart {
+func (x *AgentResponse) GetOutputs() *AgentOutputs {
 	if x != nil {
-		if x, ok := x.Type.(*AgentMessage_Start); ok {
-			return x.Start
-		}
-	}
-	return nil
-}
-
-func (x *AgentMessage) GetOutputs() *AgentOutputs {
-	if x != nil {
-		if x, ok := x.Type.(*AgentMessage_Outputs); ok {
+		if x, ok := x.Type.(*AgentResponse_Outputs); ok {
 			return x.Outputs
 		}
 	}
 	return nil
 }
 
-func (x *AgentMessage) GetEnd() *AgentEnd {
+func (x *AgentResponse) GetEnd() *AgentEnd {
 	if x != nil {
-		if x, ok := x.Type.(*AgentMessage_End); ok {
+		if x, ok := x.Type.(*AgentResponse_End); ok {
 			return x.End
 		}
 	}
 	return nil
 }
 
-type isAgentMessage_Type interface {
-	isAgentMessage_Type()
+type isAgentResponse_Type interface {
+	isAgentResponse_Type()
 }
 
-type AgentMessage_Start struct {
-	Start *AgentStart `protobuf:"bytes,3,opt,name=start,proto3,oneof"`
+type AgentResponse_Outputs struct {
+	Outputs *AgentOutputs `protobuf:"bytes,3,opt,name=outputs,proto3,oneof"`
 }
 
-type AgentMessage_Outputs struct {
-	Outputs *AgentOutputs `protobuf:"bytes,4,opt,name=outputs,proto3,oneof"`
+type AgentResponse_End struct {
+	End *AgentEnd `protobuf:"bytes,4,opt,name=end,proto3,oneof"`
 }
 
-type AgentMessage_End struct {
-	End *AgentEnd `protobuf:"bytes,5,opt,name=end,proto3,oneof"`
-}
+func (*AgentResponse_Outputs) isAgentResponse_Type() {}
 
-func (*AgentMessage_Start) isAgentMessage_Type() {}
-
-func (*AgentMessage_Outputs) isAgentMessage_Type() {}
-
-func (*AgentMessage_End) isAgentMessage_Type() {}
+func (*AgentResponse_End) isAgentResponse_Type() {}
 
 // Message is a message in the history.
 type Message struct {
@@ -358,7 +402,7 @@ type Message struct {
 
 func (x *Message) Reset() {
 	*x = Message{}
-	mi := &file_proto_ax_proto_msgTypes[4]
+	mi := &file_proto_ax_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -370,7 +414,7 @@ func (x *Message) String() string {
 func (*Message) ProtoMessage() {}
 
 func (x *Message) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[4]
+	mi := &file_proto_ax_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -383,7 +427,7 @@ func (x *Message) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Message.ProtoReflect.Descriptor instead.
 func (*Message) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{4}
+	return file_proto_ax_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Message) GetRole() string {
@@ -423,7 +467,7 @@ type ConversationEvent struct {
 
 func (x *ConversationEvent) Reset() {
 	*x = ConversationEvent{}
-	mi := &file_proto_ax_proto_msgTypes[5]
+	mi := &file_proto_ax_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -435,7 +479,7 @@ func (x *ConversationEvent) String() string {
 func (*ConversationEvent) ProtoMessage() {}
 
 func (x *ConversationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[5]
+	mi := &file_proto_ax_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -448,7 +492,7 @@ func (x *ConversationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConversationEvent.ProtoReflect.Descriptor instead.
 func (*ConversationEvent) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{5}
+	return file_proto_ax_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ConversationEvent) GetConversationId() string {
@@ -504,7 +548,7 @@ type ExecutionEvent struct {
 
 func (x *ExecutionEvent) Reset() {
 	*x = ExecutionEvent{}
-	mi := &file_proto_ax_proto_msgTypes[6]
+	mi := &file_proto_ax_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -516,7 +560,7 @@ func (x *ExecutionEvent) String() string {
 func (*ExecutionEvent) ProtoMessage() {}
 
 func (x *ExecutionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[6]
+	mi := &file_proto_ax_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -529,7 +573,7 @@ func (x *ExecutionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionEvent) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{6}
+	return file_proto_ax_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ExecutionEvent) GetExecId() string {
@@ -590,7 +634,7 @@ type HealthCheckRequest struct {
 
 func (x *HealthCheckRequest) Reset() {
 	*x = HealthCheckRequest{}
-	mi := &file_proto_ax_proto_msgTypes[7]
+	mi := &file_proto_ax_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -602,7 +646,7 @@ func (x *HealthCheckRequest) String() string {
 func (*HealthCheckRequest) ProtoMessage() {}
 
 func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[7]
+	mi := &file_proto_ax_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -615,7 +659,7 @@ func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckRequest.ProtoReflect.Descriptor instead.
 func (*HealthCheckRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{7}
+	return file_proto_ax_proto_rawDescGZIP(), []int{8}
 }
 
 // HealthCheckResponse contains agent health status
@@ -629,7 +673,7 @@ type HealthCheckResponse struct {
 
 func (x *HealthCheckResponse) Reset() {
 	*x = HealthCheckResponse{}
-	mi := &file_proto_ax_proto_msgTypes[8]
+	mi := &file_proto_ax_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -641,7 +685,7 @@ func (x *HealthCheckResponse) String() string {
 func (*HealthCheckResponse) ProtoMessage() {}
 
 func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[8]
+	mi := &file_proto_ax_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -654,7 +698,7 @@ func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckResponse.ProtoReflect.Descriptor instead.
 func (*HealthCheckResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{8}
+	return file_proto_ax_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *HealthCheckResponse) GetHealthy() bool {
@@ -685,7 +729,7 @@ type ExecRequest struct {
 
 func (x *ExecRequest) Reset() {
 	*x = ExecRequest{}
-	mi := &file_proto_ax_proto_msgTypes[9]
+	mi := &file_proto_ax_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -697,7 +741,7 @@ func (x *ExecRequest) String() string {
 func (*ExecRequest) ProtoMessage() {}
 
 func (x *ExecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[9]
+	mi := &file_proto_ax_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -710,7 +754,7 @@ func (x *ExecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecRequest.ProtoReflect.Descriptor instead.
 func (*ExecRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{9}
+	return file_proto_ax_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ExecRequest) GetConversationId() string {
@@ -759,7 +803,7 @@ type ExecResponse struct {
 
 func (x *ExecResponse) Reset() {
 	*x = ExecResponse{}
-	mi := &file_proto_ax_proto_msgTypes[10]
+	mi := &file_proto_ax_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -771,7 +815,7 @@ func (x *ExecResponse) String() string {
 func (*ExecResponse) ProtoMessage() {}
 
 func (x *ExecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[10]
+	mi := &file_proto_ax_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -784,7 +828,7 @@ func (x *ExecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResponse.ProtoReflect.Descriptor instead.
 func (*ExecResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{10}
+	return file_proto_ax_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ExecResponse) GetOutputs() []*Message {
@@ -810,7 +854,7 @@ type DeleteConversationRequest struct {
 
 func (x *DeleteConversationRequest) Reset() {
 	*x = DeleteConversationRequest{}
-	mi := &file_proto_ax_proto_msgTypes[11]
+	mi := &file_proto_ax_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -822,7 +866,7 @@ func (x *DeleteConversationRequest) String() string {
 func (*DeleteConversationRequest) ProtoMessage() {}
 
 func (x *DeleteConversationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[11]
+	mi := &file_proto_ax_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -835,7 +879,7 @@ func (x *DeleteConversationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteConversationRequest.ProtoReflect.Descriptor instead.
 func (*DeleteConversationRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{11}
+	return file_proto_ax_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DeleteConversationRequest) GetConversationId() string {
@@ -853,7 +897,7 @@ type DeleteConversationResponse struct {
 
 func (x *DeleteConversationResponse) Reset() {
 	*x = DeleteConversationResponse{}
-	mi := &file_proto_ax_proto_msgTypes[12]
+	mi := &file_proto_ax_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -865,7 +909,7 @@ func (x *DeleteConversationResponse) String() string {
 func (*DeleteConversationResponse) ProtoMessage() {}
 
 func (x *DeleteConversationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[12]
+	mi := &file_proto_ax_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -878,7 +922,7 @@ func (x *DeleteConversationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteConversationResponse.ProtoReflect.Descriptor instead.
 func (*DeleteConversationResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{12}
+	return file_proto_ax_proto_rawDescGZIP(), []int{13}
 }
 
 type ForkConversationRequest struct {
@@ -897,7 +941,7 @@ type ForkConversationRequest struct {
 
 func (x *ForkConversationRequest) Reset() {
 	*x = ForkConversationRequest{}
-	mi := &file_proto_ax_proto_msgTypes[13]
+	mi := &file_proto_ax_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -909,7 +953,7 @@ func (x *ForkConversationRequest) String() string {
 func (*ForkConversationRequest) ProtoMessage() {}
 
 func (x *ForkConversationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[13]
+	mi := &file_proto_ax_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -922,7 +966,7 @@ func (x *ForkConversationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForkConversationRequest.ProtoReflect.Descriptor instead.
 func (*ForkConversationRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{13}
+	return file_proto_ax_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ForkConversationRequest) GetSrcConversationId() string {
@@ -955,7 +999,7 @@ type ForkConversationResponse struct {
 
 func (x *ForkConversationResponse) Reset() {
 	*x = ForkConversationResponse{}
-	mi := &file_proto_ax_proto_msgTypes[14]
+	mi := &file_proto_ax_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -967,7 +1011,7 @@ func (x *ForkConversationResponse) String() string {
 func (*ForkConversationResponse) ProtoMessage() {}
 
 func (x *ForkConversationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ax_proto_msgTypes[14]
+	mi := &file_proto_ax_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -980,7 +1024,7 @@ func (x *ForkConversationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForkConversationResponse.ProtoReflect.Descriptor instead.
 func (*ForkConversationResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ax_proto_rawDescGZIP(), []int{14}
+	return file_proto_ax_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ForkConversationResponse) GetConversationId() string {
@@ -1003,13 +1047,16 @@ const file_proto_ax_proto_rawDesc = "" +
 	"\fAgentOutputs\x12'\n" +
 	"\bmessages\x18\x01 \x03(\v2\v.ax.MessageR\bmessages\"\n" +
 	"\n" +
-	"\bAgentEnd\"\xd0\x01\n" +
-	"\fAgentMessage\x12'\n" +
+	"\bAgentEnd\"v\n" +
+	"\fAgentRequest\x12'\n" +
 	"\x0fconversation_id\x18\x01 \x01(\tR\x0econversationId\x12\x17\n" +
-	"\aexec_id\x18\x02 \x01(\tR\x06execId\x12&\n" +
-	"\x05start\x18\x03 \x01(\v2\x0e.ax.AgentStartH\x00R\x05start\x12,\n" +
-	"\aoutputs\x18\x04 \x01(\v2\x10.ax.AgentOutputsH\x00R\aoutputs\x12 \n" +
-	"\x03end\x18\x05 \x01(\v2\f.ax.AgentEndH\x00R\x03endB\x06\n" +
+	"\aexec_id\x18\x02 \x01(\tR\x06execId\x12$\n" +
+	"\x05start\x18\x03 \x01(\v2\x0e.ax.AgentStartR\x05start\"\xa9\x01\n" +
+	"\rAgentResponse\x12'\n" +
+	"\x0fconversation_id\x18\x01 \x01(\tR\x0econversationId\x12\x17\n" +
+	"\aexec_id\x18\x02 \x01(\tR\x06execId\x12,\n" +
+	"\aoutputs\x18\x03 \x01(\v2\x10.ax.AgentOutputsH\x00R\aoutputs\x12 \n" +
+	"\x03end\x18\x04 \x01(\v2\f.ax.AgentEndH\x00R\x03endB\x06\n" +
 	"\x04type\"i\n" +
 	"\aMessage\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12%\n" +
@@ -1055,9 +1102,9 @@ const file_proto_ax_proto_rawDesc = "" +
 	"\x11STATE_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rSTATE_PENDING\x10\x01\x12\x10\n" +
 	"\fSTATE_FAILED\x10\x02\x12\x13\n" +
-	"\x0fSTATE_COMPLETED\x10\x032\x81\x01\n" +
-	"\fAgentService\x121\n" +
-	"\aConnect\x12\x10.ax.AgentMessage\x1a\x10.ax.AgentMessage(\x010\x01\x12>\n" +
+	"\x0fSTATE_COMPLETED\x10\x032\x80\x01\n" +
+	"\fAgentService\x120\n" +
+	"\aConnect\x12\x10.ax.AgentRequest\x1a\x11.ax.AgentResponse0\x01\x12>\n" +
 	"\vHealthCheck\x12\x16.ax.HealthCheckRequest\x1a\x17.ax.HealthCheckResponse2@\n" +
 	"\x11ControllerService\x12+\n" +
 	"\x04Exec\x12\x0f.ax.ExecRequest\x1a\x10.ax.ExecResponse0\x012\xb9\x01\n" +
@@ -1078,52 +1125,53 @@ func file_proto_ax_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_ax_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_proto_ax_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_proto_ax_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_proto_ax_proto_goTypes = []any{
 	(State)(0),                         // 0: ax.State
 	(*AgentStart)(nil),                 // 1: ax.AgentStart
 	(*AgentOutputs)(nil),               // 2: ax.AgentOutputs
 	(*AgentEnd)(nil),                   // 3: ax.AgentEnd
-	(*AgentMessage)(nil),               // 4: ax.AgentMessage
-	(*Message)(nil),                    // 5: ax.Message
-	(*ConversationEvent)(nil),          // 6: ax.ConversationEvent
-	(*ExecutionEvent)(nil),             // 7: ax.ExecutionEvent
-	(*HealthCheckRequest)(nil),         // 8: ax.HealthCheckRequest
-	(*HealthCheckResponse)(nil),        // 9: ax.HealthCheckResponse
-	(*ExecRequest)(nil),                // 10: ax.ExecRequest
-	(*ExecResponse)(nil),               // 11: ax.ExecResponse
-	(*DeleteConversationRequest)(nil),  // 12: ax.DeleteConversationRequest
-	(*DeleteConversationResponse)(nil), // 13: ax.DeleteConversationResponse
-	(*ForkConversationRequest)(nil),    // 14: ax.ForkConversationRequest
-	(*ForkConversationResponse)(nil),   // 15: ax.ForkConversationResponse
-	(*Content)(nil),                    // 16: ax.Content
-	(*timestamppb.Timestamp)(nil),      // 17: google.protobuf.Timestamp
+	(*AgentRequest)(nil),               // 4: ax.AgentRequest
+	(*AgentResponse)(nil),              // 5: ax.AgentResponse
+	(*Message)(nil),                    // 6: ax.Message
+	(*ConversationEvent)(nil),          // 7: ax.ConversationEvent
+	(*ExecutionEvent)(nil),             // 8: ax.ExecutionEvent
+	(*HealthCheckRequest)(nil),         // 9: ax.HealthCheckRequest
+	(*HealthCheckResponse)(nil),        // 10: ax.HealthCheckResponse
+	(*ExecRequest)(nil),                // 11: ax.ExecRequest
+	(*ExecResponse)(nil),               // 12: ax.ExecResponse
+	(*DeleteConversationRequest)(nil),  // 13: ax.DeleteConversationRequest
+	(*DeleteConversationResponse)(nil), // 14: ax.DeleteConversationResponse
+	(*ForkConversationRequest)(nil),    // 15: ax.ForkConversationRequest
+	(*ForkConversationResponse)(nil),   // 16: ax.ForkConversationResponse
+	(*Content)(nil),                    // 17: ax.Content
+	(*timestamppb.Timestamp)(nil),      // 18: google.protobuf.Timestamp
 }
 var file_proto_ax_proto_depIdxs = []int32{
-	5,  // 0: ax.AgentStart.messages:type_name -> ax.Message
-	5,  // 1: ax.AgentOutputs.messages:type_name -> ax.Message
-	1,  // 2: ax.AgentMessage.start:type_name -> ax.AgentStart
-	2,  // 3: ax.AgentMessage.outputs:type_name -> ax.AgentOutputs
-	3,  // 4: ax.AgentMessage.end:type_name -> ax.AgentEnd
-	16, // 5: ax.Message.content:type_name -> ax.Content
-	5,  // 6: ax.ConversationEvent.messages:type_name -> ax.Message
+	6,  // 0: ax.AgentStart.messages:type_name -> ax.Message
+	6,  // 1: ax.AgentOutputs.messages:type_name -> ax.Message
+	1,  // 2: ax.AgentRequest.start:type_name -> ax.AgentStart
+	2,  // 3: ax.AgentResponse.outputs:type_name -> ax.AgentOutputs
+	3,  // 4: ax.AgentResponse.end:type_name -> ax.AgentEnd
+	17, // 5: ax.Message.content:type_name -> ax.Content
+	6,  // 6: ax.ConversationEvent.messages:type_name -> ax.Message
 	0,  // 7: ax.ConversationEvent.state:type_name -> ax.State
-	5,  // 8: ax.ExecutionEvent.inputs:type_name -> ax.Message
-	5,  // 9: ax.ExecutionEvent.outputs:type_name -> ax.Message
+	6,  // 8: ax.ExecutionEvent.inputs:type_name -> ax.Message
+	6,  // 9: ax.ExecutionEvent.outputs:type_name -> ax.Message
 	0,  // 10: ax.ExecutionEvent.state:type_name -> ax.State
-	17, // 11: ax.ExecutionEvent.timestamp:type_name -> google.protobuf.Timestamp
-	5,  // 12: ax.ExecRequest.inputs:type_name -> ax.Message
-	5,  // 13: ax.ExecResponse.outputs:type_name -> ax.Message
-	4,  // 14: ax.AgentService.Connect:input_type -> ax.AgentMessage
-	8,  // 15: ax.AgentService.HealthCheck:input_type -> ax.HealthCheckRequest
-	10, // 16: ax.ControllerService.Exec:input_type -> ax.ExecRequest
-	12, // 17: ax.ConversationService.DeleteConversation:input_type -> ax.DeleteConversationRequest
-	14, // 18: ax.ConversationService.ForkConversation:input_type -> ax.ForkConversationRequest
-	4,  // 19: ax.AgentService.Connect:output_type -> ax.AgentMessage
-	9,  // 20: ax.AgentService.HealthCheck:output_type -> ax.HealthCheckResponse
-	11, // 21: ax.ControllerService.Exec:output_type -> ax.ExecResponse
-	13, // 22: ax.ConversationService.DeleteConversation:output_type -> ax.DeleteConversationResponse
-	15, // 23: ax.ConversationService.ForkConversation:output_type -> ax.ForkConversationResponse
+	18, // 11: ax.ExecutionEvent.timestamp:type_name -> google.protobuf.Timestamp
+	6,  // 12: ax.ExecRequest.inputs:type_name -> ax.Message
+	6,  // 13: ax.ExecResponse.outputs:type_name -> ax.Message
+	4,  // 14: ax.AgentService.Connect:input_type -> ax.AgentRequest
+	9,  // 15: ax.AgentService.HealthCheck:input_type -> ax.HealthCheckRequest
+	11, // 16: ax.ControllerService.Exec:input_type -> ax.ExecRequest
+	13, // 17: ax.ConversationService.DeleteConversation:input_type -> ax.DeleteConversationRequest
+	15, // 18: ax.ConversationService.ForkConversation:input_type -> ax.ForkConversationRequest
+	5,  // 19: ax.AgentService.Connect:output_type -> ax.AgentResponse
+	10, // 20: ax.AgentService.HealthCheck:output_type -> ax.HealthCheckResponse
+	12, // 21: ax.ControllerService.Exec:output_type -> ax.ExecResponse
+	14, // 22: ax.ConversationService.DeleteConversation:output_type -> ax.DeleteConversationResponse
+	16, // 23: ax.ConversationService.ForkConversation:output_type -> ax.ForkConversationResponse
 	19, // [19:24] is the sub-list for method output_type
 	14, // [14:19] is the sub-list for method input_type
 	14, // [14:14] is the sub-list for extension type_name
@@ -1137,10 +1185,9 @@ func file_proto_ax_proto_init() {
 		return
 	}
 	file_proto_content_proto_init()
-	file_proto_ax_proto_msgTypes[3].OneofWrappers = []any{
-		(*AgentMessage_Start)(nil),
-		(*AgentMessage_Outputs)(nil),
-		(*AgentMessage_End)(nil),
+	file_proto_ax_proto_msgTypes[4].OneofWrappers = []any{
+		(*AgentResponse_Outputs)(nil),
+		(*AgentResponse_End)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -1148,7 +1195,7 @@ func file_proto_ax_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_ax_proto_rawDesc), len(file_proto_ax_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   15,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/proto/ax.proto
+++ b/proto/ax.proto
@@ -36,13 +36,18 @@ message AgentOutputs {
 
 message AgentEnd {}
 
-message AgentMessage {
+message AgentRequest {
+  string conversation_id = 1;
+  string exec_id = 2;
+  AgentStart start = 3;
+}
+
+message AgentResponse {
   string conversation_id = 1;
   string exec_id = 2;
   oneof type {
-    AgentStart start = 3;
-    AgentOutputs outputs = 4;
-    AgentEnd end = 5;
+    AgentOutputs outputs = 3;
+    AgentEnd end = 4;
   }
 }
 
@@ -98,7 +103,7 @@ message HealthCheckResponse {
 // we are solidifying resumption on the wire.
 service AgentService {
   // Connect is used by agents to connect to the controller.
-  rpc Connect(stream AgentMessage) returns (stream AgentMessage);
+  rpc Connect(AgentRequest) returns (stream AgentResponse);
 
   // HealthCheck checks if the agent is healthy and responsive
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);

--- a/proto/ax_grpc.pb.go
+++ b/proto/ax_grpc.pb.go
@@ -50,7 +50,7 @@ const (
 // we are solidifying resumption on the wire.
 type AgentServiceClient interface {
 	// Connect is used by agents to connect to the controller.
-	Connect(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[AgentMessage, AgentMessage], error)
+	Connect(ctx context.Context, in *AgentRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AgentResponse], error)
 	// HealthCheck checks if the agent is healthy and responsive
 	HealthCheck(ctx context.Context, in *HealthCheckRequest, opts ...grpc.CallOption) (*HealthCheckResponse, error)
 }
@@ -63,18 +63,24 @@ func NewAgentServiceClient(cc grpc.ClientConnInterface) AgentServiceClient {
 	return &agentServiceClient{cc}
 }
 
-func (c *agentServiceClient) Connect(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[AgentMessage, AgentMessage], error) {
+func (c *agentServiceClient) Connect(ctx context.Context, in *AgentRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AgentResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &AgentService_ServiceDesc.Streams[0], AgentService_Connect_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &grpc.GenericClientStream[AgentMessage, AgentMessage]{ClientStream: stream}
+	x := &grpc.GenericClientStream[AgentRequest, AgentResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
 	return x, nil
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type AgentService_ConnectClient = grpc.BidiStreamingClient[AgentMessage, AgentMessage]
+type AgentService_ConnectClient = grpc.ServerStreamingClient[AgentResponse]
 
 func (c *agentServiceClient) HealthCheck(ctx context.Context, in *HealthCheckRequest, opts ...grpc.CallOption) (*HealthCheckResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -99,7 +105,7 @@ func (c *agentServiceClient) HealthCheck(ctx context.Context, in *HealthCheckReq
 // we are solidifying resumption on the wire.
 type AgentServiceServer interface {
 	// Connect is used by agents to connect to the controller.
-	Connect(grpc.BidiStreamingServer[AgentMessage, AgentMessage]) error
+	Connect(*AgentRequest, grpc.ServerStreamingServer[AgentResponse]) error
 	// HealthCheck checks if the agent is healthy and responsive
 	HealthCheck(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error)
 	mustEmbedUnimplementedAgentServiceServer()
@@ -112,7 +118,7 @@ type AgentServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedAgentServiceServer struct{}
 
-func (UnimplementedAgentServiceServer) Connect(grpc.BidiStreamingServer[AgentMessage, AgentMessage]) error {
+func (UnimplementedAgentServiceServer) Connect(*AgentRequest, grpc.ServerStreamingServer[AgentResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method Connect not implemented")
 }
 func (UnimplementedAgentServiceServer) HealthCheck(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error) {
@@ -140,11 +146,15 @@ func RegisterAgentServiceServer(s grpc.ServiceRegistrar, srv AgentServiceServer)
 }
 
 func _AgentService_Connect_Handler(srv interface{}, stream grpc.ServerStream) error {
-	return srv.(AgentServiceServer).Connect(&grpc.GenericServerStream[AgentMessage, AgentMessage]{ServerStream: stream})
+	m := new(AgentRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(AgentServiceServer).Connect(m, &grpc.GenericServerStream[AgentRequest, AgentResponse]{ServerStream: stream})
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type AgentService_ConnectServer = grpc.BidiStreamingServer[AgentMessage, AgentMessage]
+type AgentService_ConnectServer = grpc.ServerStreamingServer[AgentResponse]
 
 func _AgentService_HealthCheck_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(HealthCheckRequest)
@@ -181,7 +191,6 @@ var AgentService_ServiceDesc = grpc.ServiceDesc{
 			StreamName:    "Connect",
 			Handler:       _AgentService_Connect_Handler,
 			ServerStreams: true,
-			ClientStreams: true,
 		},
 	},
 	Metadata: "proto/ax.proto",


### PR DESCRIPTION
We don't allow sub agents to use the controller to make agent handoffs anymore.

Split AgentMessage into AgentRequest and AgentResponse proto definitions.

Fixes #4.