### PR TITLE
Add conversation snapshot checkpoints for fork and resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,11 @@ ax fork --src-conversation 38460323-9a78-41cb-8991-022b0ff2c19c \
 ax fork --src-conversation 38460323-9a78-41cb-8991-022b0ff2c19c \
         --dest-conversation e5e26e38-53a2-4f22-b1cb-ae867357df83 \
         --src-seq 12
+
+# Same checkpoint using a snapshot (conversation_id:seq)
+ax fork --src-conversation 38460323-9a78-41cb-8991-022b0ff2c19c \
+        --dest-conversation e5e26e38-53a2-4f22-b1cb-ae867357df83 \
+        --src-snapshot 38460323-9a78-41cb-8991-022b0ff2c19c:12
 ```
 
 ### Trace

--- a/cmd/ax/fork.go
+++ b/cmd/ax/fork.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/google/ax/cmd/ax/internal/cliutil"
+	"github.com/google/ax/internal/checkpoint"
 	"github.com/google/ax/internal/config"
 	"github.com/google/ax/proto"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ import (
 var (
 	forkSourceConversation string
 	forkSourceSeq          int32
+	forkSourceSnapshot     string
 	forkDestConversation   string
 	forkServerAddr         string
 	forkConfigFile         string
@@ -34,13 +36,17 @@ var (
 var forkCmd = &cobra.Command{
 	Use:   "fork",
 	Short: "Fork an event log from a specific checkpoint",
-	Long:  `Fork an existing agentic event log into a new conversation, optionally from a specific checkpoint.`,
-	RunE:  runFork,
+	Long: `Fork an existing agentic event log into a new conversation, optionally from a specific checkpoint.
+
+Checkpoints may be specified as --src-seq or as a snapshot (--src-snapshot) in the
+form "<conversation_id>:<seq>", matching the seq= value printed after ax exec.`,
+	RunE: runFork,
 }
 
 func init() {
 	forkCmd.Flags().StringVar(&forkSourceConversation, "src-conversation", "", "Source conversation ID to fork from (required)")
 	forkCmd.Flags().Int32Var(&forkSourceSeq, "src-seq", 0, "Sequence number to fork from (optional, defaults to latest)")
+	forkCmd.Flags().StringVar(&forkSourceSnapshot, "src-snapshot", "", "Snapshot checkpoint as <conversation_id>:<seq> (optional, overrides --src-seq)")
 	forkCmd.Flags().StringVar(&forkDestConversation, "dest-conversation", "", "Destination conversation ID (required)")
 	forkCmd.Flags().StringVar(&forkServerAddr, "server", "", "gRPC controller server address (if specified, connects to remote server; otherwise runs with a local built-in AX server)")
 	forkCmd.Flags().StringVar(&forkConfigFile, "config", "ax.yaml", "Path to YAML configuration file (only used with a local built-in AX server)")
@@ -52,8 +58,12 @@ func init() {
 func runFork(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
+	srcSeq, err := checkpoint.ResolveForkSeq(forkSourceConversation, forkSourceSnapshot, forkSourceSeq)
+	if err != nil {
+		return fmt.Errorf("invalid fork checkpoint: %w", err)
+	}
+
 	if forkServerAddr == "" {
-		// Headless mode
 		cfg, err := config.LoadFromFile(forkConfigFile)
 		if err != nil {
 			return fmt.Errorf("error loading config file '%s': %w", forkConfigFile, err)
@@ -65,16 +75,18 @@ func runFork(cmd *cobra.Command, args []string) error {
 		}
 		defer c.Close()
 
-		destID, err := c.Fork(ctx, forkSourceConversation, forkSourceSeq, forkDestConversation)
+		destID, err := c.Fork(ctx, forkSourceConversation, srcSeq, forkDestConversation)
 		if err != nil {
 			return fmt.Errorf("error forking conversation: %w", err)
 		}
 
 		fmt.Printf("Conversation forked successfully. New conversation ID: %s\n", destID)
+		if srcSeq > 0 {
+			fmt.Printf("Forked from snapshot: %s\n", checkpoint.At(forkSourceConversation, srcSeq))
+		}
 		return nil
 	}
 
-	// Remote mode
 	conn, err := connect(forkServerAddr)
 	if err != nil {
 		return err
@@ -85,7 +97,7 @@ func runFork(cmd *cobra.Command, args []string) error {
 
 	resp, err := client.ForkConversation(ctx, &proto.ForkConversationRequest{
 		SrcConversationId:  forkSourceConversation,
-		SrcSeq:             forkSourceSeq,
+		SrcSeq:             srcSeq,
 		DestConversationId: forkDestConversation,
 	})
 	if err != nil {

--- a/docs/checkpoint-resumption.md
+++ b/docs/checkpoint-resumption.md
@@ -1,0 +1,73 @@
+# Conversation snapshots and checkpoints
+
+AX records conversation history as a sequenced event log. A **snapshot**
+identifies a checkpoint in that log and is the first step toward a unified
+resumption protocol (see `ForkConversationRequest.src_seq` TODO for
+`snapshot_id` in `proto/ax.proto`).
+
+## Snapshot format
+
+```text
+<conversation_id>:<seq>
+```
+
+Example:
+
+```text
+d85a4b4e-c53b-4c84-b879-f10d905bce40:12
+```
+
+- `seq` is the `ConversationEvent.seq` value (the same number printed as
+  `seq=N` after `ax exec`).
+- `seq` of `0` means **latest** (include all events).
+
+## Package API
+
+`internal/checkpoint` provides:
+
+| Function | Use |
+|----------|-----|
+| `Parse` / `Snapshot.String` | Serialize checkpoints |
+| `Truncate` | Fork up to a seq |
+| `ValidateSeq` | Client catch-up (`last_seq`) |
+| `EventsAfter` | Replay events after `last_seq` |
+| `Latest` | Highest seq in a conversation |
+| `ResolveForkSeq` | CLI `--src-snapshot` parsing |
+
+## CLI usage
+
+Fork with a raw sequence (existing):
+
+```bash
+ax fork \
+  --src-conversation d85a4b4e-c53b-4c84-b879-f10d905bce40 \
+  --dest-conversation e5e26e38-53a2-4f22-b1cb-ae867357df83 \
+  --src-seq 12
+```
+
+Fork with a snapshot (preferred):
+
+```bash
+ax fork \
+  --src-conversation d85a4b4e-c53b-4c84-b879-f10d905bce40 \
+  --dest-conversation e5e26e38-53a2-4f22-b1cb-ae867357df83 \
+  --src-snapshot d85a4b4e-c53b-4c84-b879-f10d905bce40:12
+```
+
+Client catch-up after disconnect (unchanged):
+
+```bash
+ax exec \
+  --conversation d85a4b4e-c53b-4c84-b879-f10d905bce40 \
+  --last-seq 12 \
+  --resume
+```
+
+## Design notes
+
+- Snapshots reference **conversation events** only today. Execution-scoped
+  replay still uses `ExecutionEvent` entries keyed by `exec_id`.
+- Invalid `src_seq` / snapshot seq values error instead of silently forking
+  the full log.
+- Future work: proto `snapshot_id`, `conversation_id` on execution log rows,
+  merge `ConversationEvent` and `ExecutionEvent`.

--- a/docs/pr-checkpoint-snapshot.md
+++ b/docs/pr-checkpoint-snapshot.md
@@ -1,0 +1,39 @@
+## Summary
+
+Introduce a conversation **Snapshot** checkpoint type and centralize fork /
+client catch-up logic. First step toward unified resumption protocol; no proto
+or SQLite schema changes.
+
+- Adds `internal/checkpoint` with parse/format, truncate, validate, and replay helpers
+- Refactors `controller.Fork` and `tryResuming` (`last_seq`) to use the package
+- Adds `ax fork --src-snapshot <conversation_id>:<seq>` (alias for `--src-seq`)
+- Documents snapshot format in `docs/checkpoint-resumption.md`
+
+## Motivation
+
+Checkpoint handling was duplicated in the controller and tied to raw integers.
+Proto already notes replacing `src_seq` with `snapshot_id`; this PR introduces
+the Go-side snapshot type without a wire break.
+
+## Test plan
+
+- [x] `go test ./internal/checkpoint/...`
+- [x] `go test ./internal/controller/...` (fork + resumption tests)
+- [x] `make test`
+- [x] `make build`
+- [ ] Manual: `ax fork --src-snapshot conv:1 --src-conversation conv ...`
+
+## Breaking changes
+
+None. `--src-seq` and `last_seq` behavior unchanged.
+
+## Follow-ups
+
+- Add `snapshot_id` to `ForkConversationRequest` proto
+- Add `conversation_id` column to `execution_log`
+- Merge conversation and execution event types
+
+## Checklist
+
+- [ ] Signed [Google CLA](https://cla.developers.google.com/)
+- [ ] Tracking issue on google/ax (optional)

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package checkpoint provides conversation snapshot identifiers and helpers
+// for fork, resume catch-up, and future snapshot_id wire formats.
+package checkpoint
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/ax/proto"
+)
+
+// Snapshot identifies a point in a conversation event log. Seq 0 means the
+// latest event (include the full log). The string form is "<conversation_id>:<seq>"
+// and is intended to become the snapshot_id representation on the wire.
+type Snapshot struct {
+	ConversationID string
+	Seq            int32
+}
+
+// At returns a snapshot for conversationID at seq. Seq 0 selects the latest event.
+func At(conversationID string, seq int32) Snapshot {
+	return Snapshot{ConversationID: conversationID, Seq: seq}
+}
+
+// String formats the snapshot as "<conversation_id>:<seq>".
+func (s Snapshot) String() string {
+	return fmt.Sprintf("%s:%d", s.ConversationID, s.Seq)
+}
+
+// Parse parses "<conversation_id>:<seq>". Seq may be 0 for latest.
+func Parse(raw string) (Snapshot, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Snapshot{}, fmt.Errorf("checkpoint: empty snapshot")
+	}
+	i := strings.LastIndex(raw, ":")
+	if i <= 0 || i == len(raw)-1 {
+		return Snapshot{}, fmt.Errorf("checkpoint: invalid snapshot %q (want <conversation_id>:<seq>)", raw)
+	}
+	conversationID := raw[:i]
+	seqStr := raw[i+1:]
+	seq64, err := strconv.ParseInt(seqStr, 10, 32)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("checkpoint: invalid seq in snapshot %q: %w", raw, err)
+	}
+	if seq64 < 0 {
+		return Snapshot{}, fmt.Errorf("checkpoint: seq must be non-negative in snapshot %q", raw)
+	}
+	return Snapshot{ConversationID: conversationID, Seq: int32(seq64)}, nil
+}
+
+// Latest returns a snapshot at the highest seq in events, or Seq 0 when empty.
+func Latest(conversationID string, events []*proto.ConversationEvent) Snapshot {
+	var maxSeq int32
+	for _, ev := range events {
+		if ev.Seq > maxSeq {
+			maxSeq = ev.Seq
+		}
+	}
+	return Snapshot{ConversationID: conversationID, Seq: maxSeq}
+}
+
+// ValidateSeq reports whether seq appears in events. Seq 0 is always valid.
+func ValidateSeq(events []*proto.ConversationEvent, seq int32) error {
+	if seq == 0 {
+		return nil
+	}
+	for _, ev := range events {
+		if ev.Seq == seq {
+			return nil
+		}
+	}
+	return fmt.Errorf("seq %d not found", seq)
+}
+
+// Truncate returns events up to and including snap.Seq. When snap.Seq is 0,
+// all events are returned. When snap.Seq is set, it must exist in events.
+func Truncate(events []*proto.ConversationEvent, snap Snapshot) ([]*proto.ConversationEvent, error) {
+	if snap.Seq == 0 {
+		return events, nil
+	}
+	for i, ev := range events {
+		if ev.Seq == snap.Seq {
+			return events[:i+1], nil
+		}
+		if ev.Seq > snap.Seq {
+			break
+		}
+	}
+	if snap.ConversationID != "" {
+		return nil, fmt.Errorf("seq %d not found in conversation %s", snap.Seq, snap.ConversationID)
+	}
+	return nil, fmt.Errorf("seq %d not found", snap.Seq)
+}
+
+// EventsAfter returns conversation events with seq strictly greater than afterSeq,
+// preserving order.
+func EventsAfter(events []*proto.ConversationEvent, afterSeq int32) []*proto.ConversationEvent {
+	if afterSeq == 0 {
+		return nil
+	}
+	out := make([]*proto.ConversationEvent, 0)
+	for _, ev := range events {
+		if ev.Seq > afterSeq {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// ResolveForkSeq returns the sequence number to fork from. When snapshot is
+// non-empty it must parse as "<conversation_id>:<seq>" and match conversationID.
+func ResolveForkSeq(conversationID, snapshot string, fallbackSeq int32) (int32, error) {
+	if snapshot == "" {
+		return fallbackSeq, nil
+	}
+	snap, err := Parse(snapshot)
+	if err != nil {
+		return 0, err
+	}
+	if snap.ConversationID != conversationID {
+		return 0, fmt.Errorf("checkpoint: snapshot conversation %q does not match %q", snap.ConversationID, conversationID)
+	}
+	return snap.Seq, nil
+}

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/ax/proto"
+)
+
+func events(seqs ...int32) []*proto.ConversationEvent {
+	out := make([]*proto.ConversationEvent, len(seqs))
+	for i, seq := range seqs {
+		out[i] = &proto.ConversationEvent{ConversationId: "conv-1", Seq: seq}
+	}
+	return out
+}
+
+func TestParse(t *testing.T) {
+	snap, err := Parse("d85a4b4e-c53b-4c84-b879-f10d905bce40:12")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.ConversationID != "d85a4b4e-c53b-4c84-b879-f10d905bce40" || snap.Seq != 12 {
+		t.Fatalf("unexpected snapshot: %+v", snap)
+	}
+	if got := snap.String(); got != "d85a4b4e-c53b-4c84-b879-f10d905bce40:12" {
+		t.Fatalf("String() = %q", got)
+	}
+}
+
+func TestParse_Invalid(t *testing.T) {
+	cases := []string{"", "noseparator", "conv:", ":12", "conv:abc", "conv:-1"}
+	for _, raw := range cases {
+		if _, err := Parse(raw); err == nil {
+			t.Fatalf("Parse(%q) expected error", raw)
+		}
+	}
+}
+
+func TestLatest(t *testing.T) {
+	snap := Latest("conv-1", events(1, 3, 2))
+	if snap.Seq != 3 || snap.ConversationID != "conv-1" {
+		t.Fatalf("unexpected latest: %+v", snap)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	evs := events(1, 2, 3)
+
+	all, err := Truncate(evs, At("conv-1", 0))
+	if err != nil || len(all) != 3 {
+		t.Fatalf("truncate latest: len=%d err=%v", len(all), err)
+	}
+
+	partial, err := Truncate(evs, At("conv-1", 2))
+	if err != nil || len(partial) != 2 || partial[1].Seq != 2 {
+		t.Fatalf("truncate at 2: %+v err=%v", partial, err)
+	}
+
+	if _, err := Truncate(evs, At("conv-1", 99)); err == nil {
+		t.Fatal("expected error for missing seq")
+	}
+}
+
+func TestValidateSeq(t *testing.T) {
+	evs := events(1, 2)
+	if err := ValidateSeq(evs, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateSeq(evs, 2); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateSeq(evs, 9); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEventsAfter(t *testing.T) {
+	evs := events(1, 2, 3)
+	after := EventsAfter(evs, 1)
+	if len(after) != 2 || after[0].Seq != 2 || after[1].Seq != 3 {
+		t.Fatalf("unexpected after events: %+v", after)
+	}
+	if len(EventsAfter(evs, 0)) != 0 {
+		t.Fatal("expected no events after seq 0")
+	}
+}
+
+func TestAtRoundTrip(t *testing.T) {
+	s := At("abc", 5)
+	parsed, err := Parse(s.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed != s {
+		t.Fatalf("round trip mismatch: %+v vs %+v", parsed, s)
+	}
+	if !strings.Contains(s.String(), ":5") {
+		t.Fatalf("unexpected string: %s", s.String())
+	}
+}
+
+func TestResolveForkSeq(t *testing.T) {
+	seq, err := ResolveForkSeq("conv-1", "conv-1:2", 0)
+	if err != nil || seq != 2 {
+		t.Fatalf("ResolveForkSeq snapshot: seq=%d err=%v", seq, err)
+	}
+
+	seq, err = ResolveForkSeq("conv-1", "", 3)
+	if err != nil || seq != 3 {
+		t.Fatalf("ResolveForkSeq fallback: seq=%d err=%v", seq, err)
+	}
+
+	if _, err := ResolveForkSeq("conv-1", "other:2", 0); err == nil {
+		t.Fatal("expected conversation mismatch error")
+	}
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 
 	"github.com/google/ax/internal/agent"
+	"github.com/google/ax/internal/checkpoint"
 	"github.com/google/ax/internal/controller/executor"
 	"github.com/google/ax/internal/gemini"
 	"github.com/google/ax/proto"
@@ -102,22 +103,16 @@ func (d *Controller) tryResuming(ctx context.Context, req *proto.ExecRequest, el
 	}
 
 	if req.LastSeq != 0 {
-		found := false
-		for _, ev := range events {
-			if ev.Seq == req.LastSeq {
-				found = true
-			}
-			if ev.Seq > req.LastSeq {
-				if err := handler(&proto.ExecResponse{
-					Outputs: ev.Messages,
-					Seq:     ev.Seq,
-				}); err != nil {
-					return nil, false, err
-				}
-			}
-		}
-		if !found {
+		if err := checkpoint.ValidateSeq(events, req.LastSeq); err != nil {
 			return nil, false, fmt.Errorf("last_seq %d not found", req.LastSeq)
+		}
+		for _, ev := range checkpoint.EventsAfter(events, req.LastSeq) {
+			if err := handler(&proto.ExecResponse{
+				Outputs: ev.Messages,
+				Seq:     ev.Seq,
+			}); err != nil {
+				return nil, false, err
+			}
 		}
 	}
 
@@ -284,28 +279,11 @@ func (d *Controller) Fork(ctx context.Context, srcConversationID string, srcSeq 
 		return "", fmt.Errorf("source conversation %s not found or has no events", srcConversationID)
 	}
 
-	// When the caller specifies srcSeq, require that it actually exists in
-	// the source event log. Without this check a typo or stale checkpoint
-	// silently degrades to "fork all events", which is misleading. Walk
-	// the events once: stop as soon as we pass the requested seq, and
-	// truncate the slice on an exact match so the copy loop below doesn't
-	// need to re-check the bound.
-	if srcSeq > 0 {
-		found := false
-		for i, ev := range events {
-			if ev.Seq == srcSeq {
-				events = events[:i+1]
-				found = true
-				break
-			}
-			if ev.Seq > srcSeq {
-				break
-			}
-		}
-		if !found {
-			return "", fmt.Errorf("src_seq %d not found in conversation %s", srcSeq, srcConversationID)
-		}
+	truncated, err := checkpoint.Truncate(events, checkpoint.At(srcConversationID, srcSeq))
+	if err != nil {
+		return "", err
 	}
+	events = truncated
 
 	for _, ev := range events {
 		// Clone the event to update the conversation ID.


### PR DESCRIPTION
## Summary

Introduce a conversation **Snapshot** checkpoint type and centralize fork /
client catch-up logic. First step toward unified resumption protocol; no proto
or SQLite schema changes.

- Adds `internal/checkpoint` with parse/format, truncate, validate, and replay helpers
- Refactors `controller.Fork` and `tryResuming` (`last_seq`) to use the package
- Adds `ax fork --src-snapshot <conversation_id>:<seq>` (alias for `--src-seq`)
- Documents snapshot format in `docs/checkpoint-resumption.md`

## Motivation

Checkpoint handling was duplicated in the controller and tied to raw integers.
Proto already notes replacing `src_seq` with `snapshot_id`; this PR introduces
the Go-side snapshot type without a wire break.

## Test plan

- [x] `go test ./internal/checkpoint/...`
- [x] `go test ./internal/controller/...` (fork + resumption tests)
- [x] `make test`
- [x] `make build`
- [ ] Manual: `ax fork --src-snapshot conv:1 --src-conversation conv ...`

## Breaking changes

None. `--src-seq` and `last_seq` behavior unchanged.

## Follow-ups

- Add `snapshot_id` to `ForkConversationRequest` proto
- Add `conversation_id` column to `execution_log`
- Merge conversation and execution event types

## Checklist

- [x] Signed [Google CLA](https://cla.developers.google.com/)
- [ ] Tracking issue on google/ax (optional)
