### PR TITLE
[feat] Improve graceful interrupt handling and cancelable contexts in ax exec

### DIFF
--- a/cmd/ax/exec.go
+++ b/cmd/ax/exec.go
@@ -404,6 +404,20 @@ func promptUser(d *internal.Display, input string) (string, bool, error) {
 		var err error
 		input, err = d.PromptForInput()
 		if err != nil {
+			if err.Error() == "user aborted" {
+				count := atomic.AddInt32(&interruptCount, 1)
+				if count == 1 {
+					fmt.Println("\nPress Ctrl+C again to exit.")
+					go func() {
+						time.Sleep(2 * time.Second)
+						atomic.StoreInt32(&interruptCount, 0)
+					}()
+					input = "" // Continue loop to prompt again
+					continue
+				} else if count >= 2 {
+					return "", true, nil
+				}
+			}
 			return "", false, err
 		}
 	}

--- a/cmd/ax/exec.go
+++ b/cmd/ax/exec.go
@@ -46,7 +46,8 @@ var execCmd = &cobra.Command{
 	Short: "Execute a conversation or resume an existing one",
 	Long: `Execute a new conversation or resume an existing one.
 If no conversation ID is provided, a new UUID will be generated.`,
-	RunE: runExec,
+	SilenceUsage: true,
+	RunE:         runExec,
 }
 
 func init() {

--- a/cmd/ax/exec.go
+++ b/cmd/ax/exec.go
@@ -69,8 +69,12 @@ func init() {
 
 var (
 	execController *controller.Controller
+	// interruptCount tracks consecutive Ctrl+C events to support exiting on double Ctrl+C.
 	interruptCount int32
+	// activeCancel stores the cancellation function for the currently in-flight request,
+	// allowing a single Ctrl+C to cancel the active execution request rather than exiting the process.
 	activeCancel   context.CancelFunc
+	// cancelMu protects activeCancel from concurrent access across goroutines.
 	cancelMu       sync.Mutex
 )
 

--- a/cmd/ax/exec.go
+++ b/cmd/ax/exec.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -166,14 +167,31 @@ func execLoop(ctx context.Context, id string, agentID string, input string, last
 	}
 
 	for {
-		conf, err := runAutoExec(ctx, d, &proto.ExecRequest{
+		reqCtx, cancelReq := context.WithCancel(ctx)
+		cancelMu.Lock()
+		activeCancel = cancelReq
+		cancelMu.Unlock()
+
+		conf, err := runAutoExec(reqCtx, d, &proto.ExecRequest{
 			ConversationId: id,
 			AgentId:        agentID,
 			Inputs:         inputs,
 			LastSeq:        lastSeq,
 		})
 		lastSeq = 0 // disable resuming from sequence, user sees the seq on the screen
+
+		cancelMu.Lock()
+		activeCancel = nil
+		cancelMu.Unlock()
+		cancelReq()
+
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				fmt.Println("Request canceled.")
+				inputs = nil
+				agentID = ""
+				continue
+			}
 			return err
 		}
 
@@ -214,12 +232,27 @@ func execLoop(ctx context.Context, id string, agentID string, input string, last
 					}}
 				}
 
-				conf, err = runAutoExec(ctx, d, &proto.ExecRequest{
+				reqCtx, cancelReq := context.WithCancel(ctx)
+				cancelMu.Lock()
+				activeCancel = cancelReq
+				cancelMu.Unlock()
+
+				conf, err = runAutoExec(reqCtx, d, &proto.ExecRequest{
 					ConversationId: id,
 					AgentId:        agentID,
 					Inputs:         decision,
 				})
+
+				cancelMu.Lock()
+				activeCancel = nil
+				cancelMu.Unlock()
+				cancelReq()
+
 				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						fmt.Println("Request canceled.")
+						break
+					}
 					return err
 				}
 				if conf == nil {

--- a/cmd/ax/exec.go
+++ b/cmd/ax/exec.go
@@ -90,8 +90,14 @@ func runExec(cmd *cobra.Command, args []string) error {
 
 	go func() {
 		for {
-			<-sigChan
-			count := atomic.AddInt32(&interruptCount, 1)
+			sig := <-sigChan
+			if sig == syscall.SIGTERM {
+				fmt.Println("\nReceived SIGTERM, exiting...")
+				if execController != nil {
+					execController.Close()
+				}
+				os.Exit(1)
+			}
 
 			cancelMu.Lock()
 			cancelFn := activeCancel
@@ -101,6 +107,7 @@ func runExec(cmd *cobra.Command, args []string) error {
 				fmt.Println("\nCanceling current request...")
 				cancelFn()
 			} else {
+				count := atomic.AddInt32(&interruptCount, 1)
 				if count == 1 {
 					fmt.Println("\nPress Ctrl+C again to exit.")
 					go func() {
@@ -199,7 +206,7 @@ func execLoop(ctx context.Context, id string, agentID string, input string, last
 			for {
 				approved, err := d.PromptForApproval(conf.Question)
 				if err != nil {
-					if err.Error() == "user aborted" {
+					if errors.Is(err, internal.ErrUserAborted) {
 						count := atomic.AddInt32(&interruptCount, 1)
 						if count == 1 {
 							fmt.Println("\nPress Ctrl+C again to exit.")
@@ -417,7 +424,7 @@ func promptUser(d *internal.Display, input string) (string, bool, error) {
 		var err error
 		input, err = d.PromptForInput()
 		if err != nil {
-			if err.Error() == "user aborted" {
+			if errors.Is(err, internal.ErrUserAborted) {
 				count := atomic.AddInt32(&interruptCount, 1)
 				if count == 1 {
 					fmt.Println("\nPress Ctrl+C again to exit.")

--- a/cmd/ax/exec.go
+++ b/cmd/ax/exec.go
@@ -199,6 +199,19 @@ func execLoop(ctx context.Context, id string, agentID string, input string, last
 			for {
 				approved, err := d.PromptForApproval(conf.Question)
 				if err != nil {
+					if err.Error() == "user aborted" {
+						count := atomic.AddInt32(&interruptCount, 1)
+						if count == 1 {
+							fmt.Println("\nPress Ctrl+C again to exit.")
+							go func() {
+								time.Sleep(2 * time.Second)
+								atomic.StoreInt32(&interruptCount, 0)
+							}()
+							continue
+						} else if count >= 2 {
+							return nil
+						}
+					}
 					return err
 				}
 				var decision []*proto.Message

--- a/cmd/ax/exec.go
+++ b/cmd/ax/exec.go
@@ -110,10 +110,7 @@ func runExec(cmd *cobra.Command, args []string) error {
 				count := atomic.AddInt32(&interruptCount, 1)
 				if count == 1 {
 					fmt.Println("\nPress Ctrl+C again to exit.")
-					go func() {
-						time.Sleep(2 * time.Second)
-						atomic.StoreInt32(&interruptCount, 0)
-					}()
+					startInterruptResetTimer()
 				} else if count >= 2 {
 					fmt.Println("\nExiting...")
 					if execController != nil {
@@ -210,10 +207,7 @@ func execLoop(ctx context.Context, id string, agentID string, input string, last
 						count := atomic.AddInt32(&interruptCount, 1)
 						if count == 1 {
 							fmt.Println("\nPress Ctrl+C again to exit.")
-							go func() {
-								time.Sleep(2 * time.Second)
-								atomic.StoreInt32(&interruptCount, 0)
-							}()
+							startInterruptResetTimer()
 							continue
 						} else if count >= 2 {
 							return nil
@@ -428,10 +422,7 @@ func promptUser(d *internal.Display, input string) (string, bool, error) {
 				count := atomic.AddInt32(&interruptCount, 1)
 				if count == 1 {
 					fmt.Println("\nPress Ctrl+C again to exit.")
-					go func() {
-						time.Sleep(2 * time.Second)
-						atomic.StoreInt32(&interruptCount, 0)
-					}()
+					startInterruptResetTimer()
 					input = "" // Continue loop to prompt again
 					continue
 				} else if count >= 2 {
@@ -448,4 +439,11 @@ func promptUser(d *internal.Display, input string) (string, bool, error) {
 		return "", true, nil
 	}
 	return input, false, nil
+}
+
+func startInterruptResetTimer() {
+	go func() {
+		time.Sleep(2 * time.Second)
+		atomic.StoreInt32(&interruptCount, 0)
+	}()
 }

--- a/cmd/ax/exec.go
+++ b/cmd/ax/exec.go
@@ -21,7 +21,10 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/google/ax/cmd/ax/internal"
 	"github.com/google/ax/cmd/ax/internal/cliutil"
@@ -65,6 +68,9 @@ func init() {
 
 var (
 	execController *controller.Controller
+	interruptCount int32
+	activeCancel   context.CancelFunc
+	cancelMu       sync.Mutex
 )
 
 func runExec(cmd *cobra.Command, args []string) error {
@@ -78,16 +84,37 @@ func runExec(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	sigChan := make(chan os.Signal, 1)
+	sigChan := make(chan os.Signal, 2) // Buffer to not miss signals
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		<-sigChan
-		fmt.Println("\nReceived interrupt, shutting down...")
-		if execController != nil {
-			execController.Close()
+		for {
+			<-sigChan
+			count := atomic.AddInt32(&interruptCount, 1)
+
+			cancelMu.Lock()
+			cancelFn := activeCancel
+			cancelMu.Unlock()
+
+			if cancelFn != nil {
+				fmt.Println("\nCanceling current request...")
+				cancelFn()
+			} else {
+				if count == 1 {
+					fmt.Println("\nPress Ctrl+C again to exit.")
+					go func() {
+						time.Sleep(2 * time.Second)
+						atomic.StoreInt32(&interruptCount, 0)
+					}()
+				} else if count >= 2 {
+					fmt.Println("\nExiting...")
+					if execController != nil {
+						execController.Close()
+					}
+					os.Exit(1)
+				}
+			}
 		}
-		cancel()
 	}()
 
 	if execServerAddr == "" {

--- a/cmd/ax/internal/display.go
+++ b/cmd/ax/internal/display.go
@@ -31,6 +31,9 @@ var (
 	comment = lipgloss.AdaptiveColor{Dark: "#6d6d6d"}
 )
 
+// ErrUserAborted is returned when the user aborts a prompt.
+var ErrUserAborted = huh.ErrUserAborted
+
 type Display struct {
 	id string
 


### PR DESCRIPTION

### Changes
- **Silence Usage on Command Errors**: Added `SilenceUsage: true` to `execCmd` to avoid printing the full help screen on standard execution errors.
- **Shared State and Signal Handler for Double Ctrl+C**: Implemented a two-phase interrupt mechanism. The first Ctrl+C cancels the active in-flight request (if one is currently running), while the second consecutive Ctrl+C gracefully terminates the execution.
- **Cancelable Request Contexts**: Wrapped the headless and remote server execution loops in cancelable contexts (`activeCancel`), which are asynchronously canceled upon the first Ctrl+C signal.
- **Graceful Prompt Interruption**: Added handling for `internal.ErrUserAborted` in user input and approval prompts to correctly handle interrupts without throwing hard execution errors.
- **Review Feedback & Refactoring**: Standardized error checks, addressed previous PR review feedback, and refactored duplicated reset logic into `startInterruptResetTimer`.
- **Documentation**: Added clear, detailed comments explaining the coordination and purpose of the interrupt state variables (`interruptCount`, `activeCancel`, `cancelMu`).

