### PR TITLE
Make controller2 wiring work

### DIFF
--- a/cmd/ax/exec.go
+++ b/cmd/ax/exec.go
@@ -302,7 +302,6 @@ func execLoop(ctx context.Context, id string, agentID string, input string, last
 				},
 			},
 		}
-		agentID = "" // reset agent id for next turn
 	}
 }
 

--- a/cmd/ax/internal/cliutil/cliutil_harness.go
+++ b/cmd/ax/internal/cliutil/cliutil_harness.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/ax/internal/config"
 	"github.com/google/ax/internal/controller/executor"
 	"github.com/google/ax/internal/controller2"
+	"github.com/google/ax/internal/harness"
 )
 
 // Controller is the active controller type for this build.
@@ -32,7 +33,10 @@ type ExecHandler = controller2.ExecHandler
 
 // NewControllerFromConfig creates a controller2.Controller.
 func NewControllerFromConfig(ctx context.Context, cfg *config.Config) (*controller2.Controller, error) {
+	reg := controller2.NewRegistry()
+	reg.RegisterHarness("antigravity", harness.NewAntigravityHarness(""))
 	return controller2.New(ctx, controller2.Config{
+		Registry: reg,
 		EventLogBuilder: func() (executor.EventLog, error) {
 			return executor.OpenSQLiteEventLog(cfg.EventLog.SQLiteConfig.Filename)
 		},

--- a/internal/controller2/controller.go
+++ b/internal/controller2/controller.go
@@ -32,8 +32,8 @@ type ExecHandler func(resp *proto.ExecResponse) error
 // Controller is the main controller that coordinates all components.
 // It acts as a single-writer system for managing agentic loops.
 type Controller struct {
-	registry      *Registry
-	eventLog      executor.EventLog
+	registry *Registry
+	eventLog executor.EventLog
 }
 
 // Config configures the controller.
@@ -56,8 +56,8 @@ func New(ctx context.Context, cfg Config) (*Controller, error) {
 	}
 
 	return &Controller{
-		registry:      cfg.Registry,
-		eventLog:      eventLog,
+		registry: cfg.Registry,
+		eventLog: eventLog,
 	}, nil
 }
 
@@ -71,7 +71,7 @@ func (d *Controller) Exec(ctx context.Context, req *proto.ExecRequest, handler E
 
 	// TODO(jbd): Resume an incomplete execution if there exists one.
 	// TODO(jbd): Enable bringing a remote harness that implements HarnessService.
-  // TODO(anj): We need to consolidate agents and harness registration.
+	// TODO(anj): We need to consolidate agents and harness registration.
 	// Adding harness registration support temporarily.
 	h, err := d.registry.GetHarness(req.AgentId)
 	if err != nil {

--- a/internal/server/server_harness_test.go
+++ b/internal/server/server_harness_test.go
@@ -44,6 +44,7 @@ func TestServer_Fork(t *testing.T) {
 	}
 
 	c, err := controller2.New(ctx, controller2.Config{
+		Registry: controller2.NewRegistry(),
 		EventLogBuilder: func() (executor.EventLog, error) {
 			return log, nil
 		},
@@ -97,6 +98,7 @@ func TestServer_Fork_RequiresDestID(t *testing.T) {
 	}
 
 	c, err := controller2.New(ctx, controller2.Config{
+		Registry: controller2.NewRegistry(),
 		EventLogBuilder: func() (executor.EventLog, error) {
 			return log, nil
 		},


### PR DESCRIPTION
- Register the antigravity harness
- Don't reset the agent_id, we want to stick to the same agent
- Make sure registry isn't nil at controller2.New

This is a follow up for #33.

To test:
```
$ make install-harness
$ ax exec --agent antigravity --input "Hello!"
```