### PR TITLE
Rename registry methods GetInfo and GetHarness to AgentInfo and Harness to follow Go style

### DIFF
--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -195,8 +195,8 @@ func (r *Registry) Get(id string) (agent.Agent, error) {
 	return a, nil
 }
 
-// GetInfo retrieves agent metadata by ID.
-func (r *Registry) GetInfo(id string) (*agent.AgentInfo, error) {
+// AgentInfo retrieves agent metadata by ID.
+func (r *Registry) AgentInfo(id string) (*agent.AgentInfo, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/internal/controller2/controller.go
+++ b/internal/controller2/controller.go
@@ -73,7 +73,7 @@ func (d *Controller) Exec(ctx context.Context, req *proto.ExecRequest, handler E
 	// TODO(jbd): Enable bringing a remote harness that implements HarnessService.
 	// TODO(anj): We need to consolidate agents and harness registration.
 	// Adding harness registration support temporarily.
-	h, err := d.registry.GetHarness(req.AgentId)
+	h, err := d.registry.Harness(req.AgentId)
 	if err != nil {
 		// Fallback to test harness
 		log.Printf("WARNING: harness %s not found in registry, falling back to test harness: %v", req.AgentId, err)

--- a/internal/controller2/registry.go
+++ b/internal/controller2/registry.go
@@ -198,8 +198,8 @@ func (r *Registry) Get(id string) (agent.Agent, error) {
 	return a, nil
 }
 
-// GetInfo retrieves agent metadata by ID.
-func (r *Registry) GetInfo(id string) (*agent.AgentInfo, error) {
+// AgentInfo retrieves agent metadata by ID.
+func (r *Registry) AgentInfo(id string) (*agent.AgentInfo, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -247,8 +247,8 @@ func (r *Registry) RegisterHarness(id string, h harness.Harness) {
 	r.harnesses[id] = h
 }
 
-// GetHarness retrieves a harness by ID.
-func (r *Registry) GetHarness(id string) (harness.Harness, error) {
+// Harness retrieves a harness by ID.
+func (r *Registry) Harness(id string) (harness.Harness, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	h, ok := r.harnesses[id]

--- a/internal/gemini/gemini_planner.go
+++ b/internal/gemini/gemini_planner.go
@@ -37,7 +37,7 @@ const disallowConfirmationsKey contextKey = "disallowConfirmations"
 // AgentRegistry defines the interface needed by the planner to discover agents.
 type AgentRegistry interface {
 	List() []string
-	GetInfo(id string) (*agent.AgentInfo, error)
+	AgentInfo(id string) (*agent.AgentInfo, error)
 }
 
 // ContentGenerator abstracts Gemini content generation for testing.
@@ -519,7 +519,7 @@ func agentsToTools(registry AgentRegistry, nativeTools ...Tool) ([]*genai.Tool, 
 	var tools []*genai.Tool
 	// TODO(lhuan): Check if agentsToTools returns an error or empty list and return a friendly "no agent available, try later" error.
 	for _, id := range agents {
-		info, err := registry.GetInfo(id)
+		info, err := registry.AgentInfo(id)
 		if err != nil {
 			continue // Skip agents we can't get info for
 		}

--- a/internal/gemini/gemini_planner_test.go
+++ b/internal/gemini/gemini_planner_test.go
@@ -170,7 +170,7 @@ func (m *mockAgentRegistry) List() []string {
 	return nil
 }
 
-func (m *mockAgentRegistry) GetInfo(id string) (*agent.AgentInfo, error) {
+func (m *mockAgentRegistry) AgentInfo(id string) (*agent.AgentInfo, error) {
 	if m.getInfoFunc != nil {
 		return m.getInfoFunc(id)
 	}


### PR DESCRIPTION
Go getters are not prefixed with Get*.