### PR TITLE
impl: update event log mechanism in controller v2

### DIFF
--- a/internal/controller/executor/sqlite.go
+++ b/internal/controller/executor/sqlite.go
@@ -106,6 +106,7 @@ func (l *SQLiteEventLog) Append(ctx context.Context, event *proto.ConversationEv
 }
 
 // AppendExec inserts an execution event into the database.
+// TODO(anj): Remove execution_log table and AppendExec when legacy controller is removed.
 func (l *SQLiteEventLog) AppendExec(ctx context.Context, event *proto.ExecutionEvent) error {
 	payload, err := marshalOpts.Marshal(event)
 	if err != nil {

--- a/internal/controller2/controller.go
+++ b/internal/controller2/controller.go
@@ -84,13 +84,26 @@ func (d *Controller) Exec(ctx context.Context, req *proto.ExecRequest, handler E
 		return fmt.Errorf("failed to start harness session: %w", err)
 	}
 	defer exec.Close(ctx)
-
+ 
 	if err := exec.Queue(ctx, req.Inputs...); err != nil {
 		return fmt.Errorf("failed to queue inputs: %w", err)
 	}
 
+	// Log inputs before running harness
+	inputEvent := &proto.ConversationEvent{
+		ConversationId: req.ConversationId,
+		ExecId:         exec.ID(),
+		Messages:       req.Inputs,
+		State:          proto.State_STATE_PENDING,
+	}
+	if _, err := d.eventLog.Append(ctx, inputEvent); err != nil {
+		return fmt.Errorf("failed to log inputs: %w", err)
+	}
+
 	hhandler := &harnessHandler{
-		execHandler: handler,
+		conversationID: req.ConversationId,
+		eventLog:       d.eventLog,
+		execHandler:    handler,
 	}
 	if err := exec.Run(ctx, hhandler); err != nil {
 		return fmt.Errorf("harness execution turn failed: %w", err)
@@ -100,10 +113,24 @@ func (d *Controller) Exec(ctx context.Context, req *proto.ExecRequest, handler E
 }
 
 type harnessHandler struct {
-	execHandler ExecHandler
+	conversationID string
+	eventLog       executor.EventLog
+	execHandler    ExecHandler
 }
 
 func (a *harnessHandler) OnMessage(ctx context.Context, execID string, msg *proto.Message) error {
+	// Log every response received from the harness
+	event := &proto.ConversationEvent{
+		ConversationId: a.conversationID,
+		ExecId:         execID,
+		Messages:       []*proto.Message{msg},
+		State:          proto.State_STATE_PENDING,
+	}
+	// TODO(anj): The harness should send the full input sent to get this particular response.
+	if _, err := a.eventLog.Append(ctx, event); err != nil {
+		log.Printf("WARNING: failed to log streamed message: %v", err)
+	}
+
 	if a.execHandler == nil {
 		return nil
 	}
@@ -113,6 +140,15 @@ func (a *harnessHandler) OnMessage(ctx context.Context, execID string, msg *prot
 }
 
 func (a *harnessHandler) OnComplete(ctx context.Context, execID string) error {
+	// Mark the execution turn as completed in the conversation log
+	event := &proto.ConversationEvent{
+		ConversationId: a.conversationID,
+		ExecId:         execID,
+		State:          proto.State_STATE_COMPLETED,
+	}
+	if _, err := a.eventLog.Append(ctx, event); err != nil {
+		log.Printf("WARNING: failed to log completion event: %v", err)
+	}
 	return nil
 }
 

--- a/internal/controller2/controller_test.go
+++ b/internal/controller2/controller_test.go
@@ -76,6 +76,55 @@ func TestController2_ExecHelloWorld(t *testing.T) {
 	if gotText != "Hello world" {
 		t.Errorf("expected 'Hello world' output text response, got %q", gotText)
 	}
+
+	// Verify that events were logged correctly in Conversation Log
+	events, err := log.Events(ctx, cid)
+	if err != nil {
+		t.Fatalf("failed to retrieve logged events: %v", err)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 logged events, got %d", len(events))
+	}
+
+	// 1. First event should be inputs
+	if len(events[0].Messages) != 1 {
+		t.Errorf("expected 1 message in first event, got %d", len(events[0].Messages))
+	} else {
+		gotInputText := events[0].Messages[0].GetContent().GetText().GetText()
+		if gotInputText != "Trigger prompt" {
+			t.Errorf("expected 'Trigger prompt' in logged input, got %q", gotInputText)
+		}
+	}
+	if events[0].State != proto.State_STATE_PENDING {
+		t.Errorf("expected first event state to be PENDING, got %v", events[0].State)
+	}
+
+	// 2. Second event should be output
+	if len(events[1].Messages) != 1 {
+		t.Errorf("expected 1 message in second event, got %d", len(events[1].Messages))
+	} else {
+		gotOutputText := events[1].Messages[0].GetContent().GetText().GetText()
+		if gotOutputText != "Hello world" {
+			t.Errorf("expected 'Hello world' in logged output, got %q", gotOutputText)
+		}
+	}
+	if events[1].State != proto.State_STATE_PENDING {
+		t.Errorf("expected second event state to be PENDING, got %v", events[1].State)
+	}
+
+	// 3. Third event should be completion
+	if len(events[2].Messages) != 0 {
+		t.Errorf("expected 0 messages in third event, got %d", len(events[2].Messages))
+	}
+	if events[2].State != proto.State_STATE_COMPLETED {
+		t.Errorf("expected third event state to be COMPLETED, got %v", events[2].State)
+	}
+
+	// Verify that no Execution Events were logged (moving away from granular execution log)
+	if len(log.AllExecEvents) != 0 {
+		t.Errorf("expected 0 execution events in V2, got %d: %v", len(log.AllExecEvents), log.AllExecEvents)
+	}
 }
 
 func TestController2_ExecAntigravityFallback(t *testing.T) {


### PR DESCRIPTION
## Summary
- Updated `Controller.Exec` in V2 to log inputs to the conversation log with `STATE_PENDING` before running the harness.
- Updated `harnessHandler` in V2 to log each streamed response to the conversation log with `STATE_PENDING`.
- Updated `harnessHandler` in V2 to log a completion event with `STATE_COMPLETED` on turn end.
- Added `TODO(anj):` in `OnMessage` indicating that the harness should eventually send the full input with the response.
- Added `TODO(anj):` in `sqlite.go` to eventually remove the `execution_log` table and `AppendExec` method once the legacy controller is removed.
- Updated `TestController2_ExecHelloWorld` to verify that these events are correctly written to the event log and that no legacy execution logs are generated.

## Type of Change
- [x] New feature
- [x] Refactor

## Related Issues
Closes #50

## Test Plan
- [x] Unit tests pass (`go test -v ./internal/controller2/...`)
- [x] Manually verified: Ran E2E Demo (`go run cmd/e2e/main.go` Demo 1) and verified that the execution completed successfully.
- [x] Full test suite pass (`make test`)

## Notes for Reviewer
This change implements the simplified logging for Controller V2. It moves away from granular execution logs, logging only conversation-level events (inputs, outputs, completion status) which are needed for resumption.
