### PR TITLE
chore: remove SUBSTRATE_REFACTOR_CLEANUPS.md, tracked in #77

### DIFF
--- a/internal/SUBSTRATE_REFACTOR_CLEANUPS.md
+++ b/internal/SUBSTRATE_REFACTOR_CLEANUPS.md
@@ -1,9 +1,0 @@
-* Make internal/manifests/ax-deployment2.yaml the new templated ax-deployment.yaml.tmpl.
-* Remove harnesstest package.
-* Update HarnessService with the actual protocol.
-* Implement the ax harness to serve AGY and other harnesses.
-* Remove axepp.
-* Remove ate build tag.
-* Remove harnessHandler once Exec RPC is revisited.
-* Introduce a SubsrateHarness that wraps a regular Harness implementation and provides
-  automatic resume and suspension.


### PR DESCRIPTION
## Summary
- Deleted the `internal/SUBSTRATE_REFACTOR_CLEANUPS.md` file.
- The tasks inside it are now tracked in a newly created GitHub issue (#77) to keep the repository clean.

## Type of Change
- [x] Refactor

## Related Issues
Tracks #77

## Test Plan
- [x] Unit tests pass (`go test ./...` completed successfully).
- [x] Manually verified: Verified the file deletion locally and that it is committed.

## Notes for Reviewer
None.
