### PR TITLE
ci: add go mod tidy verification step to workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,6 +50,11 @@ jobs:
       with:
         go-version: '1.25'
 
+    - name: Verify go mod tidy
+      run: |
+        go mod tidy
+        git diff --exit-code go.mod go.sum
+
     - name: Build
       run: go build -v ./...
 


### PR DESCRIPTION
## Summary
- Added `Verify go mod tidy` step to the GitHub Actions Go workflow.
- This step runs `go mod tidy` and verifies that there are no uncommitted changes in `go.mod` or `go.sum` (using `git diff --exit-code`).
- This will automatically prevent any pull requests from landing untidy dependency files.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Related Issues
- Related to the manual cleanup in PR #88.

## Test Plan
- [x] Unit tests pass (`go test ./...`)
- [x] Manually verified: Ran `go mod tidy && git diff --exit-code go.mod go.sum` locally in the workspace, confirming it exits with code 0 on a clean repo.