### PR TITLE
Build antigravity package directly from pip install.

### DIFF
--- a/cmd/ax/Dockerfile
+++ b/cmd/ax/Dockerfile
@@ -17,18 +17,9 @@
 # skills/code execution. Used by both the ax-server (`ax serve`) and the harness
 # actor (`ax harness`, which forks the Python sidecar).
 #
-# Build context: repository root. The Antigravity runtime deps -- including the
-# linux/amd64 google-antigravity wheel that bundles the linux `localharness`
-# binary -- are installed offline from a "wheels" build context, so the build
-# needs no access to the private package registry. Populate the wheel cache with
-# `internal/hack/install-ax.sh --fetch-wheels` (which also drives build/deploy).
-#
-# Requires an OCI builder that supports additional build contexts and
-# RUN --mount: docker with BuildKit (default since Docker 23; older Docker: use
-# `docker buildx build`), or podman/buildah >= 4.0. For example:
-#   docker build --platform linux/amd64 \
-#     --build-context wheels=$HOME/.cache/ax-antigravity-wheels \
-#     -f cmd/ax/Dockerfile -t <ref> . && docker push <ref>
+# Build context: repository root. The image targets the cluster's linux/amd64
+# nodes, so it is built with `--platform linux/amd64`. For a standalone build:
+#   docker build --platform linux/amd64 -f cmd/ax/Dockerfile -t <ref> . && docker push <ref>
 
 # --- Stage 1: build the ax Go binary (with the harness build tag) -------------
 FROM --platform=$BUILDPLATFORM golang:1.26 AS build
@@ -48,10 +39,9 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 FROM python:3.13
 WORKDIR /app
 
-# Antigravity runtime deps, installed offline from the pre-downloaded wheels.
+# Antigravity runtime deps, installed from PyPI at build time.
 COPY python/antigravity/requirements.txt /tmp/requirements.txt
-RUN --mount=type=bind,from=wheels,target=/tmp/wheels \
-    pip install --no-cache-dir --no-index --find-links=/tmp/wheels -r /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Python sidecar (with generated proto stubs), the agent it serves, and the ax
 # binary built in stage 1.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/agent-substrate/substrate v0.0.0-20260617164646-00a90a8eda76
+	github.com/agent-substrate/substrate v0.0.0-20260617231801-9bd2be123328
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/a2aproject/a2a-go/v2 v2.2.0 h1:eayiNXYpyTOLVhhQrGmIHlcy8GnOdnwaNdYQPvS84Ik=
 github.com/a2aproject/a2a-go/v2 v2.2.0/go.mod h1:htTxMwicNXXXEwwfjuB/Pd1g7UHDrswhSievncmTVcE=
-github.com/agent-substrate/substrate v0.0.0-20260617164646-00a90a8eda76 h1:GO7ajMplVYHUXAqT4yWTWKGMWsWehoL3TI5GXOwJSvo=
-github.com/agent-substrate/substrate v0.0.0-20260617164646-00a90a8eda76/go.mod h1:TgdtEUV6iaflJTwmS8ONiGsyyJD+5okPZj2H6mM8WlA=
+github.com/agent-substrate/substrate v0.0.0-20260617231801-9bd2be123328 h1:NzkT3ac0DBVqPfjYD5MUQdyoxog6/rzc2CURYiPvptw=
+github.com/agent-substrate/substrate v0.0.0-20260617231801-9bd2be123328/go.mod h1:TgdtEUV6iaflJTwmS8ONiGsyyJD+5okPZj2H6mM8WlA=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=

--- a/internal/hack/install-ax.sh
+++ b/internal/hack/install-ax.sh
@@ -20,18 +20,6 @@ set -o pipefail
 ROOT=$(git rev-parse --show-toplevel)
 cd "${ROOT}"
 
-# Directory holding the pre-downloaded linux/amd64 wheels baked into the ax image
-# (including the google-antigravity wheel that bundles the localharness binary).
-# Populate it with `install-ax.sh --fetch-wheels`
-# (delete the directory first to refresh from scratch). Override the location
-# with the WHEELS_DIR env var.
-WHEELS_DIR="${WHEELS_DIR:-${HOME}/.cache/ax-antigravity-wheels}"
-
-# Python interpreter used by --fetch-wheels. Any Python 3 with pip works; the
-# downloaded wheels always target the container's Python (3.13) regardless of
-# this interpreter's own version. Override with the PYTHON env var.
-PYTHON="${PYTHON:-python3}"
-
 # ANSI color codes for prettier output
 COLOR_CYAN='\033[1;36m'
 COLOR_RESET='\033[0m'
@@ -76,7 +64,6 @@ function usage() {
   echo "Usage: $0 [options]"
   echo ""
   echo "Options:"
-  echo "  --fetch-wheels                        Download the antigravity wheels into WHEELS_DIR"
   echo "  --deploy-ax-server                    Build images and deploy AX server and components"
   echo "  --delete-ax-server                    Delete AX server and components from cluster"
   echo "  -h, --help                            Show this help message"
@@ -110,38 +97,9 @@ detect_container_engine() {
   fi
 }
 
-# fetch_wheels downloads the antigravity harness wheel closure into WHEELS_DIR.
-# Resolution targets linux/amd64 + CPython 3.13 regardless of the host OS or host
-# Python.
-fetch_wheels() {
-  log_step "fetch_wheels -> ${WHEELS_DIR}"
-
-  if ! "${PYTHON}" -m pip --version >/dev/null 2>&1; then
-    echo "Error: '${PYTHON} -m pip' is not available." >&2
-    echo "Install pip or set PYTHON to an interpreter that has it." >&2
-    exit 1
-  fi
-
-  mkdir -p "${WHEELS_DIR}"
-
-  "${PYTHON}" -m pip download \
-    --only-binary=:all: \
-    --python-version 3.13 \
-    --platform manylinux_2_17_x86_64 \
-    --platform manylinux2014_x86_64 \
-    --platform manylinux_2_28_x86_64 \
-    --platform manylinux1_x86_64 \
-    --platform linux_x86_64 \
-    -r python/antigravity/requirements.txt \
-    -d "${WHEELS_DIR}"
-
-  echo "Wheel cache ready: ${WHEELS_DIR}"
-}
-
 # build_ax_image builds and pushes the comprehensive ax image (the Go ax binary
 # plus the Antigravity Python sidecar) and echoes its digest-pinned reference on
-# stdout. Requires KO_DOCKER_REPO, a container engine, and a populated wheel
-# cache.
+# stdout. Requires KO_DOCKER_REPO and a container engine.
 build_ax_image() {
   if [[ -z "${KO_DOCKER_REPO:-}" ]]; then
     echo "Error: KO_DOCKER_REPO environment variable must be set" >&2
@@ -151,11 +109,6 @@ build_ax_image() {
   if ! command -v "${CONTAINER_ENGINE}" >/dev/null 2>&1; then
     echo "Error: container engine '${CONTAINER_ENGINE}' not found in PATH." >&2
     echo "Install it or set CONTAINER_ENGINE to an available builder." >&2
-    exit 1
-  fi
-  if [[ ! -d "${WHEELS_DIR}" ]] || [[ -z "$(ls -A "${WHEELS_DIR}" 2>/dev/null)" ]]; then
-    echo "Error: antigravity wheel cache '${WHEELS_DIR}' is missing or empty." >&2
-    echo "Run '$0 --fetch-wheels' to populate it (or set WHEELS_DIR)." >&2
     exit 1
   fi
 
@@ -171,14 +124,13 @@ build_ax_image() {
   log_step "build_ax_image -> ${image}" >&2
   "${CONTAINER_ENGINE}" build \
     --platform linux/amd64 \
-    --build-context "wheels=${WHEELS_DIR}" \
     -f cmd/ax/Dockerfile \
     -t "${image}" \
     . 2>&1 \
     | awk -v cyan="${COLOR_CYAN}" -v reset="${COLOR_RESET}" '
         /^\[[0-9]+\/[0-9]+\] / {
           s = $1; gsub(/[][]/, "", s); split(s, parts, "/")
-          stage = (parts[1] == "1") ? "build" : "runtime"
+          stage = (parts[1] == "1") ? "build" : "deploy"
           rest = $0; sub(/^\[[0-9]+\/[0-9]+\] /, "", rest)
           printf "%s[%s]%s %s\n", cyan, stage, reset, rest
           fflush(); next
@@ -302,7 +254,6 @@ done
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-    --fetch-wheels) fetch_wheels ;;
     --deploy-ax-server) deploy_ax_server ;;
     --delete-ax-server) delete_ax_server ;;
     *)

--- a/internal/hack/install-ax.sh
+++ b/internal/hack/install-ax.sh
@@ -117,26 +117,13 @@ build_ax_image() {
   tag="$(git rev-parse --short HEAD)"
   image="${repo}:${tag}"
 
-  # The cluster runs on linux/amd64 and the bundled localharness is an amd64
-  # binary, so the image must be amd64 regardless of the build host.
-  # Relabel multi-stage build step prefixes to friendlier tags matching log_step's
-  # style.
   log_step "build_ax_image -> ${image}" >&2
   "${CONTAINER_ENGINE}" build \
     --platform linux/amd64 \
     -f cmd/ax/Dockerfile \
     -t "${image}" \
     . 2>&1 \
-    | awk -v cyan="${COLOR_CYAN}" -v reset="${COLOR_RESET}" '
-        /^\[[0-9]+\/[0-9]+\] / {
-          s = $1; gsub(/[][]/, "", s); split(s, parts, "/")
-          stage = (parts[1] == "1") ? "build" : "deploy"
-          rest = $0; sub(/^\[[0-9]+\/[0-9]+\] /, "", rest)
-          printf "%s[%s]%s %s\n", cyan, stage, reset, rest
-          fflush(); next
-        }
-        { print; fflush() }
-      ' >&2
+    | awk '{ sub(/^\[[0-9]+\/[0-9]+\] /, ""); print; fflush() }' >&2
 
   # Push the readable tag, then resolve the pushed manifest digest so the
   # ActorTemplate can reference the image by digest (snapshot-safe).

--- a/internal/manifests/README.md
+++ b/internal/manifests/README.md
@@ -42,28 +42,15 @@ manifests to your cluster:
 #### Build prerequisites
 
 The ax image bundles the antigravity SDK and its `localharness` binary,
-installed offline from a pre-downloaded linux/amd64 wheel cache. Fetch it once
-(re-run after dependency changes):
-
-```bash
-./internal/hack/install-ax.sh --fetch-wheels
-```
-
-> [!NOTE]
-> `--fetch-wheels` resolves the **linux/amd64 + CPython 3.13** wheels regardless
-> of your host OS/Python, so Mac and Linux produce the same set. It uses your
-> host pip index configuration, which must reach the private antigravity registry
-> (override the primary index with `PIP_INDEX_URL`). Customize the cache location
-> with `WHEELS_DIR` and the interpreter with `PYTHON`.
+installed from PyPI at build time. The image targets the cluster's **linux/amd64**
+nodes and is built with `--platform linux/amd64`.
 
 You also need a container engine to build and push the ax image. The script
 auto-detects one (preferring a **running** docker, then podman); force a choice
-with `CONTAINER_ENGINE=docker` or `CONTAINER_ENGINE=podman`. The engine must
-support `--build-context` and `RUN --mount`:
+with `CONTAINER_ENGINE=docker` or `CONTAINER_ENGINE=podman`:
 
 - **Docker** — Docker Desktop (macOS; cross-builds linux/amd64 via emulation) or
-  Docker Engine (Linux; native). Requires BuildKit (default since Docker 23; on
-  older Docker use `docker buildx`). Authenticate to your registry with
+  Docker Engine (Linux; native). Authenticate to your registry with
   `gcloud auth configure-docker <region>-docker.pkg.dev` or `docker login`.
 - **Podman** — on macOS, start a machine first with `podman machine init &&
   podman machine start` (cross-builds linux/amd64 via emulation); on Linux it

--- a/python/antigravity/requirements.txt
+++ b/python/antigravity/requirements.txt
@@ -1,9 +1,4 @@
 # Runtime dependencies for the antigravity HarnessService server
 # (python/antigravity/harness_server.py).
-#
-# grpcio-health-checking is published on public PyPI but not the internal
-# mirror, so allow PyPI as an extra index for it.
---extra-index-url https://pypi.org/simple/
-
 google-antigravity==0.1.2
 grpcio-health-checking==1.81.0


### PR DESCRIPTION
- Build the `ax` image by `pip install`the Antigravity Python
  deps directly from PyPI at build time, instead of pre-downloading a linux/amd64
  wheel cache and installing it via a `wheels` build context.
- Removes the separate `--fetch-wheels` option.