### PR TITLE
Encapsulate event logging in a new logger

### DIFF
--- a/internal/controller2/controller.go
+++ b/internal/controller2/controller.go
@@ -81,25 +81,23 @@ func (d *Controller) Exec(ctx context.Context, req *proto.ExecRequest, handler E
 	}
 	defer exec.Close(ctx)
 
+	l := newLogger(d.eventLog, req.ConversationId, exec.ID(), req.AgentId)
+	if _, err := l.ResumptionState(ctx); err != nil {
+		return fmt.Errorf("failed to check resumption state: %w", err)
+	}
+
 	if err := exec.Queue(ctx, req.Inputs...); err != nil {
 		return fmt.Errorf("failed to queue inputs: %w", err)
 	}
 
 	// Log inputs before running harness
-	inputEvent := &proto.ConversationEvent{
-		ConversationId: req.ConversationId,
-		ExecId:         exec.ID(),
-		Messages:       req.Inputs,
-		State:          proto.State_STATE_PENDING,
-	}
-	if _, err := d.eventLog.Append(ctx, inputEvent); err != nil {
+	if _, err := l.LogInputs(ctx, req.Inputs, req.AgentConfig); err != nil {
 		return fmt.Errorf("failed to log inputs: %w", err)
 	}
 
 	hhandler := &harnessHandler{
-		conversationID: req.ConversationId,
-		eventLog:       d.eventLog,
-		execHandler:    handler,
+		logger:      l,
+		execHandler: handler,
 	}
 	if err := exec.Run(ctx, hhandler); err != nil {
 		return fmt.Errorf("harness execution turn failed: %w", err)
@@ -109,23 +107,16 @@ func (d *Controller) Exec(ctx context.Context, req *proto.ExecRequest, handler E
 }
 
 type harnessHandler struct {
-	conversationID string
-	eventLog       eventlog.EventLog
-	execHandler    ExecHandler
+	logger      *logger
+	execHandler ExecHandler
 }
 
 func (a *harnessHandler) OnMessage(ctx context.Context, execID string, msg *proto.Message) error {
 	// Log every response received from the harness
-	event := &proto.ConversationEvent{
-		ConversationId: a.conversationID,
-		ExecId:         execID,
-		Messages:       []*proto.Message{msg},
-		State:          proto.State_STATE_PENDING,
-	}
 	// TODO(anj): The harness should send the full input sent to get this particular response.
-	if _, err := a.eventLog.Append(ctx, event); err != nil {
+	if _, err := a.logger.LogOutputs(ctx, []*proto.Message{msg}, proto.State_STATE_PENDING); err != nil {
 		slog.WarnContext(ctx, "Failed to log streamed message to event log",
-			slog.String("conversation_id", a.conversationID),
+			slog.String("conversation_id", a.logger.conversationID),
 			slog.Any("error", err),
 		)
 	}
@@ -140,14 +131,9 @@ func (a *harnessHandler) OnMessage(ctx context.Context, execID string, msg *prot
 
 func (a *harnessHandler) OnComplete(ctx context.Context, execID string) error {
 	// Mark the execution turn as completed in the conversation log
-	event := &proto.ConversationEvent{
-		ConversationId: a.conversationID,
-		ExecId:         execID,
-		State:          proto.State_STATE_COMPLETED,
-	}
-	if _, err := a.eventLog.Append(ctx, event); err != nil {
+	if _, err := a.logger.LogOutputs(ctx, nil, proto.State_STATE_COMPLETED); err != nil {
 		slog.WarnContext(ctx, "Failed to log completion event to event log",
-			slog.String("conversation_id", a.conversationID),
+			slog.String("conversation_id", a.logger.conversationID),
 			slog.Any("error", err),
 		)
 	}
@@ -177,4 +163,66 @@ func (d *Controller) Close() error {
 		return fmt.Errorf("failed to close registry: %w", err)
 	}
 	return nil
+}
+
+func newLogger(
+	el eventlog.EventLog,
+	conversationID string,
+	execID string,
+	harnessID string) *logger {
+	return &logger{
+		el:             el,
+		conversationID: conversationID,
+		execID:         execID,
+		harnessID:      harnessID,
+	}
+}
+
+type logger struct {
+	conversationID string
+	execID         string
+	el             eventlog.EventLog
+	harnessID      string
+}
+
+func (l *logger) ResumptionState(ctx context.Context) (proto.State, error) {
+	events, err := l.el.Events(ctx, l.conversationID)
+	if err != nil {
+		return proto.State_STATE_UNSPECIFIED, err
+	}
+
+	var state proto.State
+	for _, ev := range events {
+		if ev.HarnessId != "" && ev.HarnessId != l.harnessID {
+			return proto.State_STATE_UNSPECIFIED, fmt.Errorf("resumption not allowed: harness ID changed from %s to %s", ev.HarnessId, l.harnessID)
+		}
+		if l.execID == "" || ev.ExecId == l.execID {
+			if ev.State != proto.State_STATE_UNSPECIFIED {
+				state = ev.State
+			}
+		}
+	}
+	return state, nil
+}
+
+func (l *logger) LogInputs(ctx context.Context, inputs []*proto.Message, harnessConfig []byte) (int32, error) {
+	ev := &proto.ConversationEvent{
+		ConversationId: l.conversationID,
+		ExecId:         l.execID,
+		HarnessId:      l.harnessID,
+		HarnessConfig:  harnessConfig,
+		Messages:       inputs,
+		State:          proto.State_STATE_PENDING,
+	}
+	return l.el.Append(ctx, ev)
+}
+
+func (l *logger) LogOutputs(ctx context.Context, outputs []*proto.Message, state proto.State) (int32, error) {
+	ev := &proto.ConversationEvent{
+		ConversationId: l.conversationID,
+		ExecId:         l.execID,
+		Messages:       outputs,
+		State:          state,
+	}
+	return l.el.Append(ctx, ev)
 }

--- a/internal/controller2/controller.go
+++ b/internal/controller2/controller.go
@@ -86,6 +86,10 @@ func (d *Controller) Exec(ctx context.Context, req *proto.ExecRequest, handler E
 		return fmt.Errorf("failed to check resumption state: %w", err)
 	}
 
+	// TODO(jbd): If the state is pending, first try to resume the
+	// pending execution. If the state is COMPLETED or FAILED, start
+	// a new execution.
+
 	if err := exec.Queue(ctx, req.Inputs...); err != nil {
 		return fmt.Errorf("failed to queue inputs: %w", err)
 	}

--- a/proto/ax.pb.go
+++ b/proto/ax.pb.go
@@ -515,8 +515,10 @@ type ConversationEvent struct {
 	ConversationId string                 `protobuf:"bytes,1,opt,name=conversation_id,json=conversationId,proto3" json:"conversation_id,omitempty"`
 	Seq            int32                  `protobuf:"varint,2,opt,name=seq,proto3" json:"seq,omitempty"`
 	ExecId         string                 `protobuf:"bytes,3,opt,name=exec_id,json=execId,proto3" json:"exec_id,omitempty"`
-	Messages       []*Message             `protobuf:"bytes,4,rep,name=messages,proto3" json:"messages,omitempty"`
-	State          State                  `protobuf:"varint,5,opt,name=state,proto3,enum=ax.State" json:"state,omitempty"`
+	HarnessId      string                 `protobuf:"bytes,4,opt,name=harness_id,json=harnessId,proto3" json:"harness_id,omitempty"`
+	HarnessConfig  []byte                 `protobuf:"bytes,5,opt,name=harness_config,json=harnessConfig,proto3" json:"harness_config,omitempty"`
+	Messages       []*Message             `protobuf:"bytes,6,rep,name=messages,proto3" json:"messages,omitempty"`
+	State          State                  `protobuf:"varint,7,opt,name=state,proto3,enum=ax.State" json:"state,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -570,6 +572,20 @@ func (x *ConversationEvent) GetExecId() string {
 		return x.ExecId
 	}
 	return ""
+}
+
+func (x *ConversationEvent) GetHarnessId() string {
+	if x != nil {
+		return x.HarnessId
+	}
+	return ""
+}
+
+func (x *ConversationEvent) GetHarnessConfig() []byte {
+	if x != nil {
+		return x.HarnessConfig
+	}
+	return nil
 }
 
 func (x *ConversationEvent) GetMessages() []*Message {
@@ -1392,13 +1408,16 @@ const file_proto_ax_proto_rawDesc = "" +
 	"\aMessage\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12%\n" +
 	"\acontent\x18\x02 \x01(\v2\v.ax.ContentR\acontent\x12#\n" +
-	"\rinternal_only\x18\x03 \x01(\bR\finternalOnly\"\xb1\x01\n" +
+	"\rinternal_only\x18\x03 \x01(\bR\finternalOnly\"\xf7\x01\n" +
 	"\x11ConversationEvent\x12'\n" +
 	"\x0fconversation_id\x18\x01 \x01(\tR\x0econversationId\x12\x10\n" +
 	"\x03seq\x18\x02 \x01(\x05R\x03seq\x12\x17\n" +
-	"\aexec_id\x18\x03 \x01(\tR\x06execId\x12'\n" +
-	"\bmessages\x18\x04 \x03(\v2\v.ax.MessageR\bmessages\x12\x1f\n" +
-	"\x05state\x18\x05 \x01(\x0e2\t.ax.StateR\x05state\"\x8e\x02\n" +
+	"\aexec_id\x18\x03 \x01(\tR\x06execId\x12\x1d\n" +
+	"\n" +
+	"harness_id\x18\x04 \x01(\tR\tharnessId\x12%\n" +
+	"\x0eharness_config\x18\x05 \x01(\fR\rharnessConfig\x12'\n" +
+	"\bmessages\x18\x06 \x03(\v2\v.ax.MessageR\bmessages\x12\x1f\n" +
+	"\x05state\x18\a \x01(\x0e2\t.ax.StateR\x05state\"\x8e\x02\n" +
 	"\x0eExecutionEvent\x12\x17\n" +
 	"\aexec_id\x18\x01 \x01(\tR\x06execId\x12\x19\n" +
 	"\bagent_id\x18\x02 \x01(\tR\aagentId\x12!\n" +

--- a/proto/ax.proto
+++ b/proto/ax.proto
@@ -68,8 +68,10 @@ message ConversationEvent {
   string conversation_id = 1;
   int32 seq = 2;
   string exec_id = 3;
-  repeated Message messages = 4;
-  State state = 5;
+  string harness_id = 4;
+  bytes harness_config = 5;
+  repeated Message messages = 6;
+  State state = 7;
 }
 
 // ExecutionEvent is the entry in the event log. ExecutionEvents are used
@@ -83,6 +85,9 @@ message ExecutionEvent {
   repeated Message outputs = 5;
   State state = 6;
   google.protobuf.Timestamp timestamp = 7;
+
+  // TODO(jbd): Remove agent_id and agent_config once controller2 is in place.
+  // These fields are supplied from the ConversationEvent log.
 }
 
 // HealthCheckRequest for agent health checks


### PR DESCRIPTION
- Extend ConversationEvent with harness metadata
- Don't allow Exec requests to switch to a different harness

Follow-up:
- Continue the same execution if it's not completed, or start a new execution if it's already completed.