### PR TITLE
Bump substrate version and update documentation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/a2aproject/a2a-go/v2 v2.2.0
-	github.com/agent-substrate/substrate v0.0.0-20260617231801-9bd2be123328
+	github.com/agent-substrate/substrate v0.0.0-20260622205654-fe93d160a1df
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/a2aproject/a2a-go/v2 v2.2.0 h1:eayiNXYpyTOLVhhQrGmIHlcy8GnOdnwaNdYQPvS84Ik=
 github.com/a2aproject/a2a-go/v2 v2.2.0/go.mod h1:htTxMwicNXXXEwwfjuB/Pd1g7UHDrswhSievncmTVcE=
-github.com/agent-substrate/substrate v0.0.0-20260617231801-9bd2be123328 h1:NzkT3ac0DBVqPfjYD5MUQdyoxog6/rzc2CURYiPvptw=
-github.com/agent-substrate/substrate v0.0.0-20260617231801-9bd2be123328/go.mod h1:TgdtEUV6iaflJTwmS8ONiGsyyJD+5okPZj2H6mM8WlA=
+github.com/agent-substrate/substrate v0.0.0-20260622205654-fe93d160a1df h1:Qq7cujws6kbtE/ykSlCBcZQWlpK/HQQZcmbUjJbWiUs=
+github.com/agent-substrate/substrate v0.0.0-20260622205654-fe93d160a1df/go.mod h1:TgdtEUV6iaflJTwmS8ONiGsyyJD+5okPZj2H6mM8WlA=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=

--- a/internal/hack/install-ax.sh
+++ b/internal/hack/install-ax.sh
@@ -205,12 +205,18 @@ deploy_ax_server() {
   ateom_image=$(build_ateom_image)
 
   # Render the manifest and apply it.
-  sed -e "s|\${GEMINI_API_KEY}|${GEMINI_API_KEY}|g" \
+  if ! sed -e "s|\${GEMINI_API_KEY}|${GEMINI_API_KEY}|g" \
       -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
       -e "s|\${AX_IMAGE}|${ax_image}|g" \
       -e "s|\${ATEOM_IMAGE}|${ateom_image}|g" \
       internal/manifests/ax-deployment2.yaml \
-      | run_kubectl apply -f -
+      | run_kubectl apply -f -; then
+    echo >&2
+    echo "Error: cluster rejected the manifest. An \"unknown field\" error usually means the" >&2
+    echo "cluster's substrate is incompatible with AX's go.mod pin — see" >&2
+    echo "internal/manifests/README.md (\"Substrate compatibility\")." >&2
+    exit 1
+  fi
 
   # Wait for the antigravity ActorTemplate's golden snapshot to be ready.
   log_step "wait for actortemplate/ax-harness-template to be Ready"

--- a/internal/manifests/README.md
+++ b/internal/manifests/README.md
@@ -17,18 +17,20 @@ The target Kubernetes cluster is assumed to have
 
 AX pins [Agent Substrate](https://github.com/agent-substrate/substrate) in
 `go.mod`, and the **ateom** worker image is built from that pinned version. The
-cluster's substrate **CRDs and control plane** must
-be compatible with the manifest AX applies. 
+cluster's substrate **CRDs and control plane** must be compatible with the
+manifest AX applies.
 
-When installing substrate, keep three things aligned: the
-ax `go.mod` pin = your local substrate checkout = the cluster's installed substrate.
+When installing substrate, keep three things aligned: the ax `go.mod` pin = your
+local substrate checkout = the cluster's installed substrate.
 
 ```bash
-# What version does AX pin?
-go list -m github.com/agent-substrate/substrate
+# Get AX's pinned substrate commit:
+commit=$(go list -m -f '{{.Version}}' github.com/agent-substrate/substrate | sed 's/.*-//')
+echo "$commit"   # e.g. fe93d160a1df
 
-# Align a local substrate checkout to that commit (for reading/building):
-git -C <substrate> fetch && git checkout <pinned-commit>
+# Check it out on a normal branch in your substrate clone (avoids a detached HEAD):
+git -C <substrate> fetch origin
+git -C <substrate> switch -C ax-pinned "$commit"
 ```
 
 ---

--- a/internal/manifests/README.md
+++ b/internal/manifests/README.md
@@ -13,12 +13,23 @@ Substrate.
 The target Kubernetes cluster is assumed to have
 [Agent Substrate](https://github.com/agent-substrate/substrate) installed.
 
----
+### Substrate compatibility
 
-## Harnesses
+AX pins [Agent Substrate](https://github.com/agent-substrate/substrate) in
+`go.mod`, and the **ateom** worker image is built from that pinned version. The
+cluster's substrate **CRDs and control plane** must
+be compatible with the manifest AX applies. 
 
-AX serves built-in harnesses (e.g. Antigravity) where the implementation
-and container image are provided by AX.
+When installing substrate, keep three things aligned: the
+ax `go.mod` pin = your local substrate checkout = the cluster's installed substrate.
+
+```bash
+# What version does AX pin?
+go list -m github.com/agent-substrate/substrate
+
+# Align a local substrate checkout to that commit (for reading/building):
+git -C <substrate> fetch && git checkout <pinned-commit>
+```
 
 ---
 
@@ -50,15 +61,21 @@ auto-detects one (preferring a **running** docker, then podman); force a choice
 with `CONTAINER_ENGINE=docker` or `CONTAINER_ENGINE=podman`:
 
 - **Docker** — Docker Desktop (macOS; cross-builds linux/amd64 via emulation) or
-  Docker Engine (Linux; native). Authenticate to your registry with
-  `gcloud auth configure-docker <region>-docker.pkg.dev` or `docker login`.
+  Docker Engine (Linux; native).
 - **Podman** — on macOS, start a machine first with `podman machine init &&
   podman machine start` (cross-builds linux/amd64 via emulation); on Linux it
-  runs natively (podman/buildah >= 4.0). Authenticate with a credential helper
-  or `podman login`.
+  runs natively (podman/buildah >= 4.0).
 
-Unlike `ko`, the container engine's `push` is not auto-authenticated, so make
-sure you are logged in to `$KO_DOCKER_REPO` first.
+#### Registry authentication
+
+`PROJECT_ID` sets `KO_DOCKER_REPO=gcr.io/$PROJECT_ID`. The deploy pushes two
+images — the **ax** image (via your container engine) and the **ateom** image
+(via `ko`) — and both authenticate through the gcloud credential helper:
+
+```bash
+gcloud auth login              # authenticate gcloud
+gcloud auth configure-docker   # set up the gcr.io credential helper
+```
 
 #### Deploy
 

--- a/internal/manifests/ax-deployment2.yaml
+++ b/internal/manifests/ax-deployment2.yaml
@@ -32,6 +32,8 @@ kind: WorkerPool
 metadata:
   name: ax-harness-workerpool
   namespace: ax
+  labels:
+    workload: ax-harness
 spec:
   replicas: 5
   ateomImage: ${ATEOM_IMAGE}
@@ -42,9 +44,9 @@ metadata:
   name: ax-harness-template
   namespace: ax
 spec:
-  workerPoolRef:
-    name: ax-harness-workerpool
-    namespace: ax
+  workerSelector:
+    matchLabels:
+      workload: ax-harness
   pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
   containers:
     - name: "axharness"


### PR DESCRIPTION
- Bump substrate version for latest updates.
- Update documentation substrate version compatibility, and docker/podman authentication.
  - Add instructions to sync user's substrate with ax's pinned version.
  - Add instructions to run authentication command before deployment.