### PR TITLE
controller: build Gemini planner lazily when --agent is not the planner

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -86,6 +86,15 @@ func New(ctx context.Context, cfg Config) (*Controller, error) {
 }
 
 func (d *Controller) tryResuming(ctx context.Context, req *proto.ExecRequest, el executor.EventLog, registry map[string]agent.Agent, handler ExecHandler) (history []*proto.Message, done bool, err error) {
+	// Backwards-compatible shim: build planner eagerly if this older entry
+	// point is used (no internal callers remain after the lazy refactor).
+	return d.tryResumingLazy(ctx, req, el, registry, func() error { return nil }, handler)
+}
+
+// tryResumingLazy is like tryResuming but it asks ensurePlanner to materialize
+// the planner only if the pending execution was originally driven by the
+// planner. See Exec for context.
+func (d *Controller) tryResumingLazy(ctx context.Context, req *proto.ExecRequest, el executor.EventLog, registry map[string]agent.Agent, ensurePlanner func() error, handler ExecHandler) (history []*proto.Message, done bool, err error) {
 	events, err := el.Events(ctx, req.ConversationId)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to retrieve execution history: %w", err)
@@ -142,6 +151,13 @@ func (d *Controller) tryResuming(ctx context.Context, req *proto.ExecRequest, el
 	if pendingEvent == nil {
 		return nil, false, fmt.Errorf("failed to retrieve pending event: %w", err)
 	}
+	// The pending execution may have been driven by the planner. Make sure
+	// the planner is in the registry before dispatching to the executor.
+	if pendingEvent.AgentId == plannerAgentID {
+		if err := ensurePlanner(); err != nil {
+			return nil, false, err
+		}
+	}
 	if err := d.execute(
 		ctx,
 		req.ConversationId,
@@ -161,19 +177,18 @@ func (d *Controller) tryResuming(ctx context.Context, req *proto.ExecRequest, el
 // Exec executes a new agentic loop execution or resumes an existing one.
 // If id is empty, a UUID will be generated.
 // If the execution already exists, it will be resumed with optional new inputs.
+//
+// The Gemini-based planner is built lazily: it is only constructed when the
+// execution actually needs it (either because no explicit agent was requested,
+// or because the resumed pending execution was originally driven by the
+// planner). This means callers that pass an explicit non-planner --agent do
+// not need Gemini credentials configured. See google/ax#135.
 func (d *Controller) Exec(ctx context.Context, req *proto.ExecRequest, handler ExecHandler) error {
 	if req.ConversationId == "" {
 		return fmt.Errorf("conversation_id is required")
 	}
 
-	planner, err := d.plannerBuilder(ctx, d.registry)
-	if err != nil {
-		return fmt.Errorf("failed to create planner: %w", err)
-	}
-
 	registry := maps.Clone(d.registry.Map())
-	registry[plannerAgentID] = planner
-
 	// TODO(lhuan): consider remove this.
 	registry[geminiAgentID] = gemini.NewGeminiAgent()
 
@@ -181,8 +196,32 @@ func (d *Controller) Exec(ctx context.Context, req *proto.ExecRequest, handler E
 		req.AgentId = plannerAgentID
 	}
 
-	// Replay the execution history if any.
-	history, done, err := d.tryResuming(ctx, req, d.eventLog, registry, handler)
+	// plannerNeeded returns true the first time we discover we need the
+	// Gemini planner for this Exec. We resolve it lazily so that callers
+	// passing --agent <non-planner> never pay the planner construction cost
+	// (and never require Gemini credentials).
+	ensurePlanner := func() error {
+		if _, ok := registry[plannerAgentID]; ok {
+			return nil
+		}
+		planner, err := d.plannerBuilder(ctx, d.registry)
+		if err != nil {
+			return fmt.Errorf("failed to create planner: %w", err)
+		}
+		registry[plannerAgentID] = planner
+		return nil
+	}
+
+	if req.AgentId == plannerAgentID {
+		if err := ensurePlanner(); err != nil {
+			return err
+		}
+	}
+
+	// Replay the execution history if any. tryResuming may discover that a
+	// pending execution was driven by the planner; in that case it will
+	// invoke ensurePlanner before dispatching to the executor.
+	history, done, err := d.tryResumingLazy(ctx, req, d.eventLog, registry, ensurePlanner, handler)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -16,9 +16,11 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/ax/internal/agent"
+	"github.com/google/ax/internal/config"
 	"github.com/google/ax/internal/controller/executor"
 	"github.com/google/ax/internal/controller/executor/executortest"
 	"github.com/google/ax/proto"
@@ -504,3 +506,244 @@ func (m *mockAgentFunc) Connect(ctx context.Context, conversationID string, exec
 }
 
 func (m *mockAgentFunc) Close() error { return nil }
+
+// TestController_Exec_ExplicitAgent_SkipsPlannerBuilder verifies that when
+// the caller specifies a concrete --agent (i.e. ExecRequest.AgentId is not
+// empty and is not the planner sentinel), the controller does NOT invoke the
+// planner builder. This is what allows `ax exec --agent <name>` to run with
+// no Gemini credentials configured. See google/ax#135.
+func TestController_Exec_ExplicitAgent_SkipsPlannerBuilder(t *testing.T) {
+	ctx := context.Background()
+	cid := "test-conv-explicit-agent"
+
+	log := &executortest.MemoryEventLog{}
+
+	var ranAgent bool
+	customAgent := &mockAgentFunc{
+		connectFunc: func(_ context.Context, _, _ string, _ *proto.AgentStart, _ agent.Executor, o agent.OutputHandler) error {
+			ranAgent = true
+			return o(&proto.AgentOutputs{
+				Messages: []*proto.Message{{
+					Role:    "assistant",
+					Content: &proto.Content{Type: &proto.Content_Text{Text: &proto.TextContent{Text: "hi from custom"}}},
+				}},
+			})
+		},
+	}
+
+	var plannerBuilderCalls int
+	c, err := New(ctx, Config{
+		EventLogBuilder: func() (executor.EventLog, error) {
+			return log, nil
+		},
+		PlannerBuilder: func(_ context.Context, _ *Registry) (agent.Agent, error) {
+			plannerBuilderCalls++
+			return nil, errors.New("no Gemini credentials configured (test sentinel: planner builder must not be called when --agent is explicit)")
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if err := c.Registry().RegisterLocal(config.LocalAgentConfig{
+		ID:    "custom",
+		Name:  "Custom",
+		Agent: customAgent,
+	}); err != nil {
+		t.Fatalf("RegisterLocal: %v", err)
+	}
+
+	var msgs []*proto.Message
+	handler := ExecHandler(func(resp *proto.ExecResponse) error {
+		msgs = append(msgs, resp.Outputs...)
+		return nil
+	})
+
+	err = c.Exec(ctx, &proto.ExecRequest{
+		ConversationId: cid,
+		AgentId:        "custom",
+		Inputs: []*proto.Message{
+			{Role: "user", Content: &proto.Content{Type: &proto.Content_Text{Text: &proto.TextContent{Text: "hello"}}}},
+		},
+	}, handler)
+	if err != nil {
+		t.Fatalf("Exec returned unexpected error: %v", err)
+	}
+	if plannerBuilderCalls != 0 {
+		t.Fatalf("plannerBuilder was called %d time(s); want 0 (it must not be built when --agent is explicit)", plannerBuilderCalls)
+	}
+	if !ranAgent {
+		t.Fatal("custom agent was not run")
+	}
+	if len(msgs) != 1 || msgs[0].GetContent().GetText().GetText() != "hi from custom" {
+		t.Fatalf("unexpected outputs: %v", msgs)
+	}
+}
+
+// TestController_Exec_DefaultAgent_BuildsPlanner verifies that when no
+// --agent is provided, the controller still builds the planner (the existing
+// default behaviour is preserved).
+func TestController_Exec_DefaultAgent_BuildsPlanner(t *testing.T) {
+	ctx := context.Background()
+	cid := "test-conv-default-agent"
+
+	log := &executortest.MemoryEventLog{}
+	var plannerBuilderCalls int
+	c, err := New(ctx, Config{
+		EventLogBuilder: func() (executor.EventLog, error) {
+			return log, nil
+		},
+		PlannerBuilder: func(_ context.Context, _ *Registry) (agent.Agent, error) {
+			plannerBuilderCalls++
+			return &dummyAgent{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	err = c.Exec(ctx, &proto.ExecRequest{
+		ConversationId: cid,
+		Inputs: []*proto.Message{
+			{Role: "user", Content: &proto.Content{Type: &proto.Content_Text{Text: &proto.TextContent{Text: "hello"}}}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plannerBuilderCalls != 1 {
+		t.Fatalf("plannerBuilder was called %d time(s); want 1 (planner is required when --agent is not provided)", plannerBuilderCalls)
+	}
+}
+
+// TestController_Exec_ResumePlannerExec_BuildsPlanner verifies that when an
+// in-flight pending execution was originally driven by the planner, resuming
+// it builds the planner even if the new request did not specify --agent (and
+// thus would otherwise default to the planner anyway). This guards against a
+// regression where the lazy-build refactor would skip the build during
+// resumption.
+func TestController_Exec_ResumePlannerExec_BuildsPlanner(t *testing.T) {
+	ctx := context.Background()
+	cid := "test-conv-resume-planner"
+	execID := "test-exec-resume-planner"
+
+	log := &executortest.MemoryEventLog{
+		AllEvents: []*proto.ConversationEvent{
+			{
+				ConversationId: cid,
+				ExecId:         execID,
+				State:          proto.State_STATE_PENDING,
+				Seq:            1,
+			},
+		},
+		AllExecEvents: []*proto.ExecutionEvent{
+			{
+				ExecId:  execID,
+				AgentId: plannerAgentID,
+				State:   proto.State_STATE_PENDING,
+				Outputs: []*proto.Message{
+					{
+						Role: "assistant",
+						Content: &proto.Content{
+							Type: &proto.Content_Confirmation{
+								Confirmation: &proto.ConfirmationContent{Question: "?"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var plannerBuilderCalls int
+	c, err := New(ctx, Config{
+		EventLogBuilder: func() (executor.EventLog, error) { return log, nil },
+		PlannerBuilder: func(_ context.Context, _ *Registry) (agent.Agent, error) {
+			plannerBuilderCalls++
+			return &dummyAgent{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if err := c.Exec(ctx, &proto.ExecRequest{ConversationId: cid}, func(*proto.ExecResponse) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if plannerBuilderCalls != 1 {
+		t.Fatalf("plannerBuilder was called %d time(s); want 1 (resuming a planner-driven exec must build the planner)", plannerBuilderCalls)
+	}
+}
+
+// TestController_Exec_ResumeCustomAgentExec_SkipsPlanner verifies the
+// symmetric case: when the pending execution was driven by an explicit
+// custom agent, resuming it must NOT require a planner.
+func TestController_Exec_ResumeCustomAgentExec_SkipsPlanner(t *testing.T) {
+	ctx := context.Background()
+	cid := "test-conv-resume-custom"
+	execID := "test-exec-resume-custom"
+
+	log := &executortest.MemoryEventLog{
+		AllEvents: []*proto.ConversationEvent{
+			{
+				ConversationId: cid,
+				ExecId:         execID,
+				State:          proto.State_STATE_PENDING,
+				Seq:            1,
+			},
+		},
+		AllExecEvents: []*proto.ExecutionEvent{
+			{
+				ExecId:  execID,
+				AgentId: "custom",
+				State:   proto.State_STATE_PENDING,
+				Outputs: []*proto.Message{
+					{
+						Role: "assistant",
+						Content: &proto.Content{
+							Type: &proto.Content_Confirmation{
+								Confirmation: &proto.ConfirmationContent{Question: "?"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	customAgent := &mockAgentFunc{
+		connectFunc: func(_ context.Context, _, _ string, _ *proto.AgentStart, _ agent.Executor, _ agent.OutputHandler) error {
+			return nil
+		},
+	}
+
+	var plannerBuilderCalls int
+	c, err := New(ctx, Config{
+		EventLogBuilder: func() (executor.EventLog, error) { return log, nil },
+		PlannerBuilder: func(_ context.Context, _ *Registry) (agent.Agent, error) {
+			plannerBuilderCalls++
+			return nil, errors.New("planner builder must not be called when resuming a custom-agent exec")
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if err := c.Registry().RegisterLocal(config.LocalAgentConfig{
+		ID:    "custom",
+		Agent: customAgent,
+	}); err != nil {
+		t.Fatalf("RegisterLocal: %v", err)
+	}
+
+	if err := c.Exec(ctx, &proto.ExecRequest{ConversationId: cid, AgentId: "custom"}, func(*proto.ExecResponse) error { return nil }); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if plannerBuilderCalls != 0 {
+		t.Fatalf("plannerBuilder was called %d time(s); want 0", plannerBuilderCalls)
+	}
+}


### PR DESCRIPTION
## Summary
Previously `controller.Exec` always constructed the Gemini planner before dispatching, even when the caller passed an explicit `--agent <name>`. As a result, every `ax exec --agent <name>` invocation required Gemini credentials to be configured on the local AX server, even when the user's selected agent never touched Gemini.

This change defers the Gemini planner construction until it is actually needed:
- New executions skip the planner build when `req.AgentId` is set to a concrete (non-planner) agent.
- Resumed executions build the planner only if the pending execution was originally driven by the planner (`pendingEvent.AgentId == "__planner"`).

The eager-build path is preserved via a small lazy helper, so the default behavior (`ax exec` with no `--agent`) is unchanged.

## Test coverage
Added 4 controller unit tests:
- `TestController_Exec_ExplicitAgent_SkipsPlannerBuilder` — `--agent <name>` must not call `plannerBuilder`
- `TestController_Exec_DefaultAgent_BuildsPlanner` — default behavior preserved
- `TestController_Exec_ResumePlannerExec_BuildsPlanner` — resuming planner-driven exec still builds planner
- `TestController_Exec_ResumeCustomAgentExec_SkipsPlanner` — resuming custom-agent exec must not require planner

Fixes #135