### PR TITLE
Set AGY working directory to /ax and move ax binary to /usr/local/bin

### DIFF
--- a/cmd/ax/Dockerfile
+++ b/cmd/ax/Dockerfile
@@ -47,7 +47,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # binary built in stage 1.
 COPY python/ /app/python
 COPY examples/antigravity_agent/ /app/examples/antigravity_agent
-COPY --from=build /out/ax /ax
+COPY --from=build /out/ax /usr/local/bin/ax
 
 # `from python.proto import ...` needs /app on the path; the generated stubs do
 # `from proto import ...`, which needs /app/python.
@@ -56,11 +56,14 @@ ENV PYTHONPATH=/app:/app/python
 # Flush stdout/stderr immediately so server logs surface in container logs.
 ENV PYTHONUNBUFFERED=1
 
+# Change working directory so that AGY doesn't pick up its own source code
+WORKDIR /ax
+
 EXPOSE 80
 
 # Default command for local docker runs. Substrate ignores the image CMD and runs
 # the ActorTemplate `command` instead. `ax harness` forks the Python sidecar,
 # which serves the HarnessService on :80.
-CMD ["/ax", "harness", \
+CMD ["ax", "harness", \
      "--antigravity-agent-file", "/app/examples/antigravity_agent/agent.py", \
      "--host", "0.0.0.0", "--port", "80"]

--- a/internal/manifests/ax-deployment2.yaml
+++ b/internal/manifests/ax-deployment2.yaml
@@ -54,7 +54,8 @@ spec:
       # Substrate ignores the image CMD/ENV/WORKDIR, so the harness command and
       # environment are specified here. `ax harness` forks the Antigravity Python
       # sidecar, which serves on port 80 because substrate DNATs workerPodIP:80.
-      command: ["/ax", "harness",
+      workingDir: /ax
+      command: ["ax", "harness",
                 "--antigravity-agent-file", "/app/examples/antigravity_agent/agent.py",
                 "--host", "0.0.0.0", "--port", "80"]
       env:
@@ -171,7 +172,7 @@ spec:
       containers:
         - name: ax-server
           image: ${AX_IMAGE}
-          command: ["/ax", "serve", "--config", "/etc/ax/ax.yaml"]
+          command: ["ax", "serve", "--config", "/etc/ax/ax.yaml"]
           ports:
             - containerPort: 8494
           env:


### PR DESCRIPTION
Fixes https://github.com/google/ax/issues/145 and https://github.com/google/ax/issues/150.

As discussed in issue 150, setting the working directory for the AGY harness to `/ax` keeps it from picking up its own source code which resides in `/app`. To facilitate this, the `ax` binary is moved to `/usr/local/bin/ax`, avoiding path conflicts.
