### PR TITLE
Isolate the harness working directory and ax source directory

### DIFF
--- a/cmd/ax/Dockerfile
+++ b/cmd/ax/Dockerfile
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 # already ships bash, git, curl, wget, ca-certificates, build-essential, and the
 # common CLIs (find/ps/less/grep/sed/...).
 FROM python:3.13
-WORKDIR /app
+WORKDIR /ax
 
 # Antigravity runtime deps, installed from PyPI at build time.
 COPY python/antigravity/requirements.txt /tmp/requirements.txt
@@ -45,15 +45,15 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Python sidecar (with generated proto stubs), the agent it serves, and the ax
 # binary built in stage 1.
-COPY python/ /app/python
-COPY examples/antigravity_agent/ /app/examples/antigravity_agent
-COPY examples/skills/ /app/skills/
-ENV SKILLS_DIR=/app/skills
-COPY --from=build /out/ax /ax
+COPY python/ /ax-app/python
+COPY examples/antigravity_agent/ /ax-app/examples/antigravity_agent
+COPY examples/skills/ /ax-app/skills/
+ENV SKILLS_DIR=/ax-app/skills
+COPY --from=build /out/ax /ax-app/ax
 
-# `from python.proto import ...` needs /app on the path; the generated stubs do
-# `from proto import ...`, which needs /app/python.
-ENV PYTHONPATH=/app:/app/python
+# `from python.proto import ...` needs /ax-app on the path; the generated stubs do
+# `from proto import ...`, which needs /ax-app/python.
+ENV PYTHONPATH=/ax-app:/ax-app/python
 
 # Flush stdout/stderr immediately so server logs surface in container logs.
 ENV PYTHONUNBUFFERED=1
@@ -63,6 +63,6 @@ EXPOSE 80
 # Default command for local docker runs. Substrate ignores the image CMD and runs
 # the ActorTemplate `command` instead. `ax harness` forks the Python sidecar,
 # which serves the HarnessService on :80.
-CMD ["/ax", "harness", \
-     "--antigravity-agent-file", "/app/examples/antigravity_agent/agent.py", \
+CMD ["/ax-app/ax", "harness", \
+     "--antigravity-agent-file", "/ax-app/examples/antigravity_agent/agent.py", \
      "--host", "0.0.0.0", "--port", "80"]

--- a/cmd/ax/harness.go
+++ b/cmd/ax/harness.go
@@ -49,10 +49,29 @@ func init() {
 	rootCmd.AddCommand(harnessCmd)
 }
 
+// setHarnessWorkDir changes the process working directory to AX_HARNESS_WORKDIR
+// when it is set. The forked Python sidecar inherits it, which scopes the agent's
+// default workspace (os.getcwd()) away from its own source tree.
+func setHarnessWorkDir() error {
+	dir := os.Getenv("AX_HARNESS_WORKDIR")
+	if dir == "" {
+		return nil
+	}
+	if err := os.Chdir(dir); err != nil {
+		return fmt.Errorf("set harness working directory %q: %w", dir, err)
+	}
+	log.Printf("harness working directory set to %s", dir)
+	return nil
+}
+
 // runHarness forks the Antigravity Python sidecar server, which serves the
 // HarnessService (and gRPC health) on the configured port. ax harness supervises
 // the child: it forwards termination signals and exits with the child's status.
 func runHarness(cmd *cobra.Command, args []string) error {
+	if err := setHarnessWorkDir(); err != nil {
+		return err
+	}
+
 	py := exec.Command("python3", "-m", "python.antigravity.harness_server",
 		"--host", harnessHost,
 		"--port", strconv.Itoa(harnessPort),

--- a/cmd/ax/harness_test.go
+++ b/cmd/ax/harness_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetHarnessWorkDir(t *testing.T) {
+	// os.Chdir is global process state; save and restore it around the test.
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	t.Run("unset leaves the working directory unchanged", func(t *testing.T) {
+		t.Setenv("AX_HARNESS_WORKDIR", "")
+		before, _ := os.Getwd()
+		if err := setHarnessWorkDir(); err != nil {
+			t.Fatalf("setHarnessWorkDir: %v", err)
+		}
+		after, _ := os.Getwd()
+		if before != after {
+			t.Errorf("working directory changed: %q -> %q", before, after)
+		}
+	})
+
+	t.Run("set changes the working directory", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("AX_HARNESS_WORKDIR", dir)
+		if err := setHarnessWorkDir(); err != nil {
+			t.Fatalf("setHarnessWorkDir: %v", err)
+		}
+		got, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+		want, _ := filepath.EvalSymlinks(dir)
+		gotResolved, _ := filepath.EvalSymlinks(got)
+		if gotResolved != want {
+			t.Errorf("working directory = %q, want %q", gotResolved, want)
+		}
+	})
+
+	t.Run("missing directory returns an error", func(t *testing.T) {
+		t.Setenv("AX_HARNESS_WORKDIR", filepath.Join(t.TempDir(), "does-not-exist"))
+		if err := setHarnessWorkDir(); err == nil {
+			t.Error("expected an error for a missing directory, got nil")
+		}
+	})
+}

--- a/manifests/ax-deployment.yaml
+++ b/manifests/ax-deployment.yaml
@@ -54,18 +54,20 @@ spec:
       # Substrate ignores the image CMD/ENV/WORKDIR, so the harness command and
       # environment are specified here. `ax harness` forks the Antigravity Python
       # sidecar, which serves on port 80 because substrate DNATs workerPodIP:80.
-      command: ["/ax", "harness",
-                "--antigravity-agent-file", "/app/examples/antigravity_agent/agent.py",
+      command: ["/ax-app/ax", "harness",
+                "--antigravity-agent-file", "/ax-app/examples/antigravity_agent/agent.py",
                 "--host", "0.0.0.0", "--port", "80"]
       env:
         - name: GEMINI_API_KEY
           value: "${GEMINI_API_KEY}"
         - name: PYTHONPATH
-          value: "/app:/app/python"
+          value: "/ax-app:/ax-app/python"
         - name: PYTHONUNBUFFERED
           value: "1"
         - name: SKILLS_DIR
-          value: "/app/skills"
+          value: "/ax-app/skills"
+        - name: AX_HARNESS_WORKDIR
+          value: "/ax"
   snapshotsConfig:
     location: gs://${BUCKET_NAME}/antigravity/
 ---
@@ -173,7 +175,7 @@ spec:
       containers:
         - name: ax-server
           image: ${AX_IMAGE}
-          command: ["/ax", "serve", "--config", "/etc/ax/ax.yaml"]
+          command: ["/ax-app/ax", "serve", "--config", "/etc/ax/ax.yaml"]
           ports:
             - containerPort: 8494
           env:


### PR DESCRIPTION
## Summary
- Run the Antigravity harness agent in a dedicated working directory `/ax`, separate from the application's own files, which now live under `/ax-app`.
- This scopes the agent's default workspace to `/ax` so it can no longer read or modify its own source tree.

Fixes #145
Fixes #150

### Caveats
This PR  denies the file-write tools (`create_file`/`edit_file`) on any path outside `/ax`. But because of the nature that substrate actor is running as root user on a worker, it's still possible if an arbitrary shell command tries to modify files outside the working directory. Proper policy is needed when antigravity allows such shell commands.

## Tested
Example run
```
⏺ what file can you read/write

Thinking: **Investigating File Access**

I'm currently focused on determining the accessible files. I need to understand the structure within the active workspace, `/ax`, pointed towards CorpusName `/ax`. I'm exploring the directory contents or searching within `/ax` to identify the project type and available files for reading or writing.


**Investigating /ax directory**

I've discovered `/ax` is empty. Now I'm shifting focus to determine if other accessible directories exist or if read/write operations are possible within `/ax` or adjacent file paths. I'm also examining the system description for clues about workspaces, particularly the role of URIs and CorpusNames, as multiple URIs are involved.



I can read and write files within the active workspace directory at [/ax](file:///ax). Additionally, I can create and update:

* **Artifacts** in the artifact directory: [/root/.gemini/antigravity/brain/045e15fb21660153b271a6a9294628fb](file:///root/.gemini/antigravity/brain/045e15fb21660153b271a6a9294628fb)
* **Scratch scripts/files** in the scratch directory: [/root/.gemini/antigravity/brain/045e15fb21660153b271a6a9294628fb/scratch/](file:///root/.gemini/antigravity/brain/045e15fb21660153b271a6a9294628fb/scratch/)

Currently, the workspace directory [/ax](file:///ax) is empty. Please let me know what files or projects you would like to create or work on!

***

### Summary of Work
* **Workspace Check**: Verified the active workspace at [/ax](file:///ax) is currently empty and informed you about the locations where files can be read/written.
seq=9

⏺ can you update the file /ax-app/python/antigravity/harness_server.py?

Thinking: **Exploring File Access**

I'm currently focused on the implications of a file path outside the user's apparent workspace. The initial request pointed to `/ax-app/python/antigravity/harness_server.py`, which is outside `/ax`. Now I'm exploring the access boundaries to see if that's permissible.


**Clarifying Permissions Conflict**

I've hit a snag. The system flagged a "user denied permission" error during tool execution. Now, I'm trying to discern if this is a deliberate user rejection or an automated system-level block. I need to be sure before I proceed with any further steps. I am consulting the user's workspace for more clues.


**Pinpointing Access Restriction**

I've determined my access is restricted to the active workspace, `/ax`. Attempts to interact with files outside of this directory, specifically `/ax-app/python/antigravity/harness_server.py`, were blocked due to permission restrictions. I am now certain the previous error was a system-level block, not user intent. I will inform the user on the reason of the error.



I located the file at [/ax-app/python/antigravity/harness_server.py](file:///ax-app/python/antigravity/harness_server.py), but attempting to access it was denied with a permission error.

Since my active workspace and code-modification boundaries are restricted to [/ax](file:///ax), I cannot view or update files outside of this workspace path, including those in `/ax-app`.

If you copy or move the file (or the relevant codebase) into [/ax](file:///ax), I will be more than happy to help you read, modify, and update it!

***

### Summary of Work
* **Search for File**: Located the file [/ax-app/python/antigravity/harness_server.py](file:///ax-app/python/antigravity/harness_server.py) using search.
* **Permission Check**: Attempted to view the file content, which was restricted due to workspace permission boundaries.
seq=16
```