### PR TITLE
Update skills dir on substrate.

### DIFF
--- a/cmd/ax/Dockerfile
+++ b/cmd/ax/Dockerfile
@@ -47,8 +47,8 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # binary built in stage 1.
 COPY python/ /ax-app/python
 COPY examples/antigravity_agent/ /ax-app/examples/antigravity_agent
-COPY examples/skills/ /ax-app/skills/
-ENV SKILLS_DIR=/ax-app/skills
+COPY examples/skills/ /ax/skills/
+ENV SKILLS_DIR=/ax/skills
 COPY --from=build /out/ax /ax-app/ax
 
 # `from python.proto import ...` needs /ax-app on the path; the generated stubs do

--- a/manifests/ax-deployment.yaml
+++ b/manifests/ax-deployment.yaml
@@ -65,7 +65,7 @@ spec:
         - name: PYTHONUNBUFFERED
           value: "1"
         - name: SKILLS_DIR
-          value: "/ax-app/skills"
+          value: "/ax/skills"
         - name: AX_HARNESS_WORKDIR
           value: "/ax"
   snapshotsConfig:


### PR DESCRIPTION
Update skills dir from `/ax-app/skills` to `/ax/skills`, so the harness is able to read/write/exec skills.