### PR TITLE
 Minimize the AX Docker image (1.35GB -> 360MB)

### DIFF
--- a/cmd/ax/Dockerfile
+++ b/cmd/ax/Dockerfile
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 # Comprehensive AX image: the Go `ax` binary plus the Antigravity Python sidecar
-# (SDK, localharness, agent), on a Debian-based image with shell tooling for
-# skills/code execution. Used by both the ax-server (`ax serve`) and the harness
-# actor (`ax harness`, which forks the Python sidecar).
+# (SDK, localharness, agent), on a Debian-slim base with the shell tooling that
+# skills/code execution need. Used by both the ax-server (`ax serve`) and the
+# harness actor (`ax harness`, which forks the Python sidecar).
 #
 # Build context: repository root. The image targets the cluster's linux/amd64
 # nodes, so it is built with `--platform linux/amd64`. For a standalone build:
@@ -32,16 +32,34 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -tags=harness -o /out/ax ./cmd/ax
 
-# --- Stage 2: comprehensive runtime (Debian + Python + Antigravity) -----------
-# Python image: a full Debian base (buildpack-deps) that
-# already ships bash, git, curl, wget, ca-certificates, build-essential, and the
-# common CLIs (find/ps/less/grep/sed/...).
-FROM python:3.13
+# --- Stage 2: install the Antigravity Python deps ------------------------------
+# Built on the full python:3.13 image so any package that ships an sdist (rather
+# than a wheel) can still compile. The deps are installed into an isolated prefix
+# that is copied into the slim runtime below, so no compilers reach the final
+# image.
+FROM python:3.13 AS pydeps
+COPY python/antigravity/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --prefix=/python-deps -r /tmp/requirements.txt
+
+# --- Stage 3: slim runtime (Debian-slim + Python + Antigravity) ----------------
+# python:3.13-slim is ~6x smaller than python:3.13. It already ships bash and the
+# coreutils CLIs (find/grep/sed/ls/...); we add only the extra tooling that
+# skills and code execution rely on.
+FROM python:3.13-slim
 WORKDIR /ax
 
-# Antigravity runtime deps, installed from PyPI at build time.
-COPY python/antigravity/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        less \
+        procps \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Antigravity runtime deps, built in stage 2. Same Python 3.13 minor version, so
+# the prefix merges cleanly into the runtime's /usr/local.
+COPY --from=pydeps /python-deps /usr/local
 
 # Python sidecar (with generated proto stubs), the agent it serves, and the ax
 # binary built in stage 1.

--- a/cmd/ax/dashboard.go
+++ b/cmd/ax/dashboard.go
@@ -52,7 +52,7 @@ var dashboardCmd = &cobra.Command{
 }
 
 func init() {
-	dashboardCmd.Flags().StringVar(&dashboardAddr, "addr", "localhost:8080", "Server address to listen on")
+	dashboardCmd.Flags().StringVar(&dashboardAddr, "addr", "127.0.0.1:8080", "Server address to listen on")
 	dashboardCmd.Flags().StringVar(&dashboardConfigFile, "config", "ax.yaml", "Path to YAML configuration file")
 }
 
@@ -175,7 +175,7 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 	addr := listener.Addr().String()
 	host, port, err := net.SplitHostPort(addr)
 	if err == nil && (host == "::" || host == "0.0.0.0" || host == "" || host == "[::]") {
-		addr = fmt.Sprintf("localhost:%s", port)
+		addr = fmt.Sprintf("127.0.0.1:%s", port)
 	}
 	url := fmt.Sprintf("http://%s", addr)
 

--- a/cmd/ax/harnessclient.go
+++ b/cmd/ax/harnessclient.go
@@ -46,7 +46,7 @@ var harnessClientCmd = &cobra.Command{
 }
 
 func init() {
-	harnessClientCmd.Flags().StringVar(&harnessServerAddr, "server", "localhost:50053", "The server address for the gRPC HarnessService.")
+	harnessClientCmd.Flags().StringVar(&harnessServerAddr, "server", "127.0.0.1:50053", "The server address for the gRPC HarnessService.")
 	harnessClientCmd.Flags().StringVar(&harnessClientID, "harness", "testharness", "The harness id to send on the request envelope.")
 	rootCmd.AddCommand(harnessClientCmd)
 }

--- a/cmd/ax/internal/cliutil/cliutil_test.go
+++ b/cmd/ax/internal/cliutil/cliutil_test.go
@@ -33,7 +33,7 @@ func TestNewControllerFromConfig_DefaultHarness(t *testing.T) {
 		Harnesses: config.HarnessesConfig{
 			Antigravity: config.AntigravityHarnessConfig{
 				Default:  true,
-				Endpoint: "localhost:50053",
+				Endpoint: "127.0.0.1:50053",
 			},
 		},
 	}

--- a/internal/cmd/e2e/main.go
+++ b/internal/cmd/e2e/main.go
@@ -67,7 +67,7 @@ func main() {
 	runDemo(ctx, "antigravity", func(reg *controller.Registry) {
 		// With the new stateful gRPC-based streaming harness, connectivity checks on the
 		// server address replace the build-time checks for local script file presence.
-		address := "localhost:50053"
+		address := "127.0.0.1:50053"
 		conn, err := net.DialTimeout("tcp", address, 1*time.Second)
 		if err != nil {
 			log.Fatalf("Antigravity harness server not active at %s: %v", address, err)

--- a/internal/harness/substrate_test.go
+++ b/internal/harness/substrate_test.go
@@ -39,7 +39,7 @@ var substrateHarnessConfig = []byte(`{"model":"gemini-2.5-pro"}`)
 // non-nil the standard health service is registered. Returns the listen address.
 func startHealthTestServer(t *testing.T, hs *health.Server) string {
 	t.Helper()
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestWaitForHealthy_StatusChange(t *testing.T) {
 
 func TestWaitForHealthy_ServerDown(t *testing.T) {
 	// Reserve a port then release it so nothing is listening there.
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}

--- a/python/antigravity/harness_server.py
+++ b/python/antigravity/harness_server.py
@@ -308,7 +308,7 @@ def enhance_config_from_env(config) -> None:
 def main():
     parser = argparse.ArgumentParser(description="Antigravity gRPC Harness Server")
     parser.add_argument("--port", type=int, default=50053, help="Port to bind the server to")
-    parser.add_argument("--host", default="localhost", help="Host to bind the server to")
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind the server to")
     args = parser.parse_args()
 
     global loaded_config

--- a/python/antigravity/harness_server_test.py
+++ b/python/antigravity/harness_server_test.py
@@ -33,11 +33,11 @@ def test_grpc_connect_success(mock_config, monkeypatch):
         server = grpc.aio.server()
         servicer = AntigravityHarnessServiceServicer()
         ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
-        port = server.add_insecure_port("localhost:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         await server.start()
         
         # 2. Connect async stub channel
-        addr = f"localhost:{port}"
+        addr = f"127.0.0.1:{port}"
         async with grpc.aio.insecure_channel(addr) as channel:
             stub = ax_pb2_grpc.HarnessServiceStub(channel)
             
@@ -101,10 +101,10 @@ def test_grpc_connect_agent_reused(mock_config, monkeypatch):
         server = grpc.aio.server()
         servicer = AntigravityHarnessServiceServicer()
         ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
-        port = server.add_insecure_port("localhost:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         await server.start()
         
-        addr = f"localhost:{port}"
+        addr = f"127.0.0.1:{port}"
         async with grpc.aio.insecure_channel(addr) as channel:
             stub = ax_pb2_grpc.HarnessServiceStub(channel)
             
@@ -193,10 +193,10 @@ def test_health_check():
         health_servicer = health.aio.HealthServicer()
         health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
         await health_servicer.set("", health_pb2.HealthCheckResponse.SERVING)
-        port = server.add_insecure_port("localhost:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         await server.start()
         try:
-            async with grpc.aio.insecure_channel(f"localhost:{port}") as channel:
+            async with grpc.aio.insecure_channel(f"127.0.0.1:{port}") as channel:
                 stub = health_pb2_grpc.HealthStub(channel)
                 resp = await stub.Check(health_pb2.HealthCheckRequest(service=""))
                 assert resp.status == health_pb2.HealthCheckResponse.SERVING
@@ -216,10 +216,10 @@ def test_grpc_connect_missing_credentials(mock_config, monkeypatch):
         server = grpc.aio.server()
         servicer = AntigravityHarnessServiceServicer()
         ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
-        port = server.add_insecure_port("localhost:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         await server.start()
         
-        addr = f"localhost:{port}"
+        addr = f"127.0.0.1:{port}"
         async with grpc.aio.insecure_channel(addr) as channel:
             stub = ax_pb2_grpc.HarnessServiceStub(channel)
             
@@ -267,10 +267,10 @@ def test_grpc_connect_programmatic_credentials(monkeypatch):
         server = grpc.aio.server()
         servicer = AntigravityHarnessServiceServicer()
         ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
-        port = server.add_insecure_port("localhost:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         await server.start()
         
-        addr = f"localhost:{port}"
+        addr = f"127.0.0.1:{port}"
         async with grpc.aio.insecure_channel(addr) as channel:
             stub = ax_pb2_grpc.HarnessServiceStub(channel)
             
@@ -345,10 +345,10 @@ def test_grpc_connect_buffering(mock_config, monkeypatch):
         server = grpc.aio.server()
         servicer = AntigravityHarnessServiceServicer()
         ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
-        port = server.add_insecure_port("localhost:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         await server.start()
         
-        addr = f"localhost:{port}"
+        addr = f"127.0.0.1:{port}"
         async with grpc.aio.insecure_channel(addr) as channel:
             stub = ax_pb2_grpc.HarnessServiceStub(channel)
             


### PR DESCRIPTION
Switch the runtime base from python:3.13 (buildpack-deps, ~1GB) to python:3.13-slim, move the Antigravity pip install into a separate builder stage so no compilers reach the final image, install only the shell tooling skills/code execution need, and drop git (~119MB).

Also replace localhost with 127.0.0.1 in case localhost is not in the hosts file.