### PR TITLE
Minimize the AX Docker image (1.35GB -> 360MB) for faster resumption on Substrate

### DIFF
--- a/cmd/ax/Dockerfile
+++ b/cmd/ax/Dockerfile
@@ -32,12 +32,17 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -tags=harness -o /out/ax ./cmd/ax
 
-# --- Stage 2: comprehensive runtime (Debian + Python + Antigravity) -----------
-# Python image: a full Debian base (buildpack-deps) that
-# already ships bash, git, curl, wget, ca-certificates, build-essential, and the
-# common CLIs (find/ps/less/grep/sed/...).
-FROM python:3.13
+FROM python:3.13-slim
 WORKDIR /ax
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        less \
+        procps \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
 
 # Antigravity runtime deps, installed from PyPI at build time.
 COPY python/antigravity/requirements.txt /tmp/requirements.txt

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,37 +1,15 @@
 # AX Harness Deployment on Kubernetes
 
 > [!WARNING]
-> 🚧 **The `harness` deployment path is under active development.**
 >
 > This path is experimental and incomplete: the manifests, scripts, and
 > runtime behavior will change and may break without notice.
 
 This directory contains Kubernetes manifests and configurations to deploy
-and verify the AX `harness` configuration path on Kubernetes using Agent
-Substrate.
+and verify the AX on Kubernetes using Agent Substrate.
 
 The target Kubernetes cluster is assumed to have
 [Agent Substrate](https://github.com/agent-substrate/substrate) installed.
-
-### Substrate compatibility
-
-AX pins [Agent Substrate](https://github.com/agent-substrate/substrate) in
-`go.mod`, and the **ateom** worker image is built from that pinned version. The
-cluster's substrate **CRDs and control plane** must be compatible with the
-manifest AX applies.
-
-When installing substrate, keep three things aligned: the ax `go.mod` pin = your
-local substrate checkout = the cluster's installed substrate.
-
-```bash
-# Get AX's pinned substrate commit:
-commit=$(go list -m -f '{{.Version}}' github.com/agent-substrate/substrate | sed 's/.*-//')
-echo "$commit"   # e.g. fe93d160a1df
-
-# Check it out on a normal branch in your substrate clone (avoids a detached HEAD):
-git -C <substrate> fetch origin
-git -C <substrate> switch -C ax-pinned "$commit"
-```
 
 ---
 
@@ -45,17 +23,14 @@ git -C <substrate> switch -C ax-pinned "$commit"
 The installation script builds the required images and applies the resolved
 manifests to your cluster:
 
-- the comprehensive **ax** image, built from `cmd/ax/Dockerfile` with Docker or
-  Podman (the `harness`-tagged Go `ax` binary plus the Antigravity Python sidecar
-  on a Debian base). The ax-server runs `ax serve`; the harness actor runs
-  `ax harness`, which forks the sidecar;
+- the comprehensive **ax** image, built from `cmd/ax/Dockerfile`,
 - the **ateom-gvisor** worker image, built with `ko` from the `go.mod` pinned
   substrate module.
 
 #### Build prerequisites
 
-The ax image bundles the antigravity SDK and its `localharness` binary,
-installed from PyPI at build time. The image targets the cluster's **linux/amd64**
+The ax image bundles the antigravity SDK, installed from PyPI at build time.
+The image targets the cluster's **linux/amd64**
 nodes and is built with `--platform linux/amd64`.
 
 You also need a container engine to build and push the ax image. The script
@@ -90,8 +65,6 @@ export BUCKET_NAME="snapshot-substrate-test-$PROJECT_ID"
 ```
 
 ### 2. Port-Forward Services
-
-The `harness` path has no Envoy router or `Service`; connect directly to the `ax-server` `ReplicaSet`:
 
 ```bash
 # Port-forward the ax-server ReplicaSet
@@ -152,4 +125,24 @@ List the pods running in the `ax` namespace:
 ```bash
 # Add `-o wide` to see node/IP assignments, or `-w` to watch status changes.
 kubectl get pods -n ax
+```
+
+## Substrate compatibility
+
+AX pins [Agent Substrate](https://github.com/agent-substrate/substrate) in
+`go.mod`, and the **ateom** worker image is built from that pinned version. The
+cluster's substrate **CRDs and control plane** must be compatible with the
+manifest AX applies.
+
+When installing substrate, keep three things aligned: the ax `go.mod` pin = your
+local substrate checkout = the cluster's installed substrate.
+
+```bash
+# Get AX's pinned substrate commit:
+commit=$(go list -m -f '{{.Version}}' github.com/agent-substrate/substrate | sed 's/.*-//')
+echo "$commit"   # e.g. fe93d160a1df
+
+# Check it out on a normal branch in your substrate clone (avoids a detached HEAD):
+git -C <substrate> fetch origin
+git -C <substrate> switch -C ax-pinned "$commit"
 ```

--- a/python/antigravity/harness_server.py
+++ b/python/antigravity/harness_server.py
@@ -304,6 +304,25 @@ def enhance_config_from_env(config) -> None:
         if skills_dir not in config.skills_paths:
             config.skills_paths.append(skills_dir)
 
+def resolve_localhost():
+    """Ensure `localhost` resolves to 127.0.0.1.
+
+    Substrate actors run under gVisor with no runtime-injected /etc/hosts.
+    The antigravity SDK dials localharness at ws://localhost:<port>/
+    and Python's resolver needs `localhost` in /etc/hosts.
+    """
+    try:
+        try:
+            with open("/etc/hosts", "r") as f:
+                if "localhost" in f.read():
+                    return
+        except FileNotFoundError:
+            pass
+        with open("/etc/hosts", "a") as f:
+            f.write("127.0.0.1\tlocalhost\n")
+    except OSError as e:
+        print(f"WARNING: could not ensure localhost in /etc/hosts: {e}", file=sys.stderr)
+
 
 def main():
     parser = argparse.ArgumentParser(description="Antigravity gRPC Harness Server")
@@ -313,6 +332,10 @@ def main():
 
     global loaded_config
     enhance_config_from_env(loaded_config)
+
+    # This is a hack, on Agent Substrate /etc/hosts end up not
+    # having this entry even if it's the OCI image.
+    resolve_localhost()
         
     asyncio.run(serve(args.host, args.port))
 


### PR DESCRIPTION
Update Dockerfile to use python:3.13-slim and install runtime dependencies.

Revert the resolve_localhost removal. Even if /etc/hosts change is included in the Dockerfile, the entry disappears in runtime. Reverting the change to make AGY harness work on Substrate again. This is a hack and needs to be removed once we resolve the issue.

Simplify the README and the instructions for Substrate deployment.