### PR TITLE
Add a line with kubectl port-forward instructions

### DIFF
--- a/hack/install-ax.sh
+++ b/hack/install-ax.sh
@@ -240,6 +240,10 @@ deploy_ax_server() {
   wait_with_spinner "waiting for golden snapshot (timeout ${AX_WAIT_TIMEOUT:-5m})" \
     run_kubectl wait --for=condition=Ready actortemplate/ax-harness-template \
     -n ax --timeout="${AX_WAIT_TIMEOUT:-5m}"
+
+  echo ""
+  echo "Forward the AX server by running the following command (optional)"
+  echo "kubectl port-forward -n ax rs/ax-server 8494:8494"
 }
 
 # delete_ax_server removes the AX server and harness resources but preserves the


### PR DESCRIPTION
Output looks like:

```
...
namespace/ax unchanged
workerpool.ate.dev/ax-harness-workerpool created
actortemplate.ate.dev/ax-harness-template created
service/ax-eventlog-postgres unchanged
secret/ax-eventlog-postgres configured
statefulset.apps/ax-eventlog-postgres configured
replicaset.apps/ax-server created
configmap/ax-server-config created
[step]: wait for statefulset/ax-eventlog-postgres to be ready
waiting for postgres (timeout 5m)... done
[step]: wait for actortemplate/ax-harness-template to be Ready
waiting for golden snapshot (timeout 5m)... done

Forward the AX server by running the following command (optional)
kubectl port-forward -n ax rs/ax-server 8494:8494
```

Fixes #169.