### PR TITLE
antigravity: forward GOOGLE_CLOUD_{PROJECT,LOCATION} env to AGY config

### DIFF
--- a/python/antigravity/harness_server.py
+++ b/python/antigravity/harness_server.py
@@ -22,6 +22,7 @@ import asyncio
 import logging
 import os
 import sys
+from typing import TypedDict
 import grpc
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 from google.protobuf.struct_pb2 import Struct
@@ -52,59 +53,121 @@ def get_weather(city: str) -> str:
     else:
         return f"Weather information for '{city}' is not available."
 
-# 2. Define the static agent config
-loaded_config = LocalAgentConfig(
-    system_instructions="You are a helpful agent. Use the get_weather tool to answer weather questions.",
-    tools=[get_weather]
-)
+class VertexKwargs(TypedDict, total=False):
+    """Typed subset of LocalAgentConfig kwargs needed to enable Vertex AI.
 
-def _has_credentials(config: AgentConfig | None) -> bool:
-    """Checks if Gemini credentials are set either in env or config."""
-    # Check environment variables
-    has_api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    use_vertex = (
+    `total=False` so {} is a valid value (returned when env does not request
+    Vertex). When populated, all three keys are present.
+    """
+    vertex: bool
+    project: str
+    location: str
+
+
+def _env_use_vertex() -> bool:
+    """True if env requests the Vertex AI backend (vs. AI Studio API key)."""
+    return (
         os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").lower() in ("true", "1") or
         os.environ.get("GOOGLE_GENAI_USE_ENTERPRISE", "").lower() in ("true", "1")
     )
-    if has_api_key or use_vertex:
+
+def _vertex_kwargs_from_env() -> VertexKwargs:
+    """Returns LocalAgentConfig kwargs from GOOGLE_CLOUD_{PROJECT,LOCATION} env.
+
+    Temporary override until AGY supports reading these env vars natively.
+    Returns {} when env does not request Vertex (caller's programmatic config
+    stands as-is). When env requests Vertex, returns VertexKwargs populated
+    for passing to LocalAgentConfig.__init__ so AGY's @model_validator picks
+    them up.
+
+    Raises ValueError if env requests Vertex but project/location are missing.
+
+    TODO: remove once AGY reads these env vars natively.
+    """
+    if not _env_use_vertex():
+        return {}
+
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT", "")
+    location = os.environ.get("GOOGLE_CLOUD_LOCATION", "")
+
+    missing = [
+        name for name, value in (
+            ("project (set GOOGLE_CLOUD_PROJECT)", project),
+            ("location (set GOOGLE_CLOUD_LOCATION)", location),
+        ) if not value
+    ]
+    if missing:
+        raise ValueError(
+            "Vertex AI backend requested but missing required config: "
+            + ", ".join(missing)
+        )
+
+    print(f"Vertex AI backend configured: project={project} location={location}")
+    return {"vertex": True, "project": project, "location": location}
+
+def _build_default_config() -> LocalAgentConfig:
+    """Builds the default agent config the sidecar serves on startup.
+
+    Vertex configuration is read from env via `_vertex_kwargs_from_env`.
+
+    TODO(#194): per-request `harness_config` will override fields of this
+    default on a per-conversation basis. Until then, every conversation uses
+    this config.
+    """
+    return LocalAgentConfig(
+        system_instructions="You are a helpful agent. Use the get_weather tool to answer weather questions.",
+        tools=[get_weather],
+        **_vertex_kwargs_from_env(),
+    )
+
+def _has_credentials(config: AgentConfig | None) -> bool:
+    """Checks if Gemini credentials are set per AGY's accepted sources.
+
+    Mirrors AGY's own validation. AGY accepts exactly these sources:
+      1. GEMINI_API_KEY environment variable (read directly by AGY).
+      2. config.api_key set programmatically (AI Studio path).
+      3. config.vertex=True + config.{project,location} set (Vertex path).
+      4. config.vertex=True + config.api_key set (Vertex Express Mode;
+         covered by case 2).
+
+    Anything else (e.g. vertex=True without project/location) is rejected
+    by AGY at request time, so we reject it here at startup too.
+    """
+    # Check env - AGY reads GEMINI_API_KEY directly from os.environ.
+    if os.environ.get("GEMINI_API_KEY"):
         return True
-        
-    # Check configuration
+
+    # Check passed in config
     if config:
-        # Check nested gemini_config
-        gemini_config = getattr(config, "gemini_config", None)
-        if gemini_config:
-            # 1. Direct configuration
-            if getattr(gemini_config, "api_key", None) or getattr(gemini_config, "vertex", False):
-                return True
-            # 2. Per-model configuration
-            models = getattr(gemini_config, "models", None)
-            default_model = getattr(models, "default", None) if models else None
-            if default_model and getattr(default_model, "api_key", None):
-                return True
-                
-        # Check top-level config shorthands
-        if getattr(config, "api_key", None) or getattr(config, "vertex", False):
+        if getattr(config, "api_key", None):
             return True
-            
+        if getattr(config, "vertex", False):
+            # Vertex requires project + location, unless an api_key (Express
+            # Mode) is set - but Express Mode would have returned True above.
+            if getattr(config, "project", None) and getattr(config, "location", None):
+                return True
+
     return False
 
 class AntigravityHarnessServiceServicer(ax_pb2_grpc.HarnessServiceServicer):
     """Implements the ax.HarnessService protocol over gRPC."""
 
-    def __init__(self):
+    def __init__(self, default_config: AgentConfig):
         # TODO: Implement an eviction/idle-timeout policy to prevent unbounded memory growth in production.
+        self._default_config = default_config
         self._agents = {}
         self._lock = asyncio.Lock()
 
     async def _get_or_create_agent(self, conversation_id: str) -> Agent:
         async with self._lock:
             if conversation_id not in self._agents:
-                global loaded_config
-                if not loaded_config:
+                # TODO(#194): derive a per-conversation AgentConfig by layering
+                # request.start.harness_config on top of self._default_config,
+                # instead of using the default verbatim for every conversation.
+                if not self._default_config:
                     raise ValueError("Agent config is not loaded on the server")
                 print(f"[gRPC] Creating new Agent instance for conv_id={conversation_id}")
-                agent = Agent(loaded_config)
+                agent = Agent(self._default_config)
                 await agent.__aenter__()
                 self._agents[conversation_id] = agent
             return self._agents[conversation_id]
@@ -162,9 +225,8 @@ class AntigravityHarnessServiceServicer(ax_pb2_grpc.HarnessServiceServicer):
             return
         latest_query_text = latest_message.content.text.text
         
-        # 2. Initialize or get the Antigravity Agent session
-        global loaded_config
-        if not loaded_config:
+        # TODO(#194): parse and validate request.start.harness_config here.
+        if not self._default_config:
             yield ax_pb2.HarnessResponse(
                 conversation_id=request.conversation_id,
                 end=ax_pb2.HarnessEnd(
@@ -172,23 +234,6 @@ class AntigravityHarnessServiceServicer(ax_pb2_grpc.HarnessServiceServicer):
                     error=ax_pb2.Error(
                         code=9,  # FAILED_PRECONDITION
                         description="Agent config is not loaded on the server",
-                    ),
-                ),
-            )
-            return
-            
-        # Check credentials
-        if not _has_credentials(loaded_config):
-            yield ax_pb2.HarnessResponse(
-                conversation_id=request.conversation_id,
-                end=ax_pb2.HarnessEnd(
-                    state=ax_pb2.STATE_FAILED,
-                    error=ax_pb2.Error(
-                        code=9,  # FAILED_PRECONDITION
-                        description=(
-                            "No Gemini credentials configured. Please set the GEMINI_API_KEY environment variable "
-                            "(AI Studio) or GOOGLE_GENAI_USE_VERTEXAI=True (Vertex AI) before starting the harness server."
-                        ),
                     ),
                 ),
             )
@@ -302,9 +347,9 @@ class AntigravityHarnessServiceServicer(ax_pb2_grpc.HarnessServiceServicer):
             )
             return
 
-async def serve(host: str, port: int):
+async def _serve(host: str, port: int, default_config: AgentConfig):
     server = grpc.aio.server()
-    servicer = AntigravityHarnessServiceServicer()
+    servicer = AntigravityHarnessServiceServicer(default_config)
     ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
 
     # Serve the standard gRPC health protocol.
@@ -321,7 +366,7 @@ async def serve(host: str, port: int):
     finally:
         await servicer.cleanup()
 
-def enhance_config_from_env(config) -> None:
+def _enhance_config_from_env(config) -> None:
     skills_dir = os.environ.get("SKILLS_DIR")
     if skills_dir and os.path.isdir(skills_dir):
         print(f"Adding preinstalled skills directory to agent config: {skills_dir}")
@@ -331,7 +376,7 @@ def enhance_config_from_env(config) -> None:
         if skills_dir not in config.skills_paths:
             config.skills_paths.append(skills_dir)
 
-def resolve_localhost():
+def _resolve_localhost():
     """Ensure `localhost` resolves to 127.0.0.1.
 
     Substrate actors run under gVisor with no runtime-injected /etc/hosts.
@@ -357,14 +402,25 @@ def main():
     parser.add_argument("--host", default="localhost", help="Host to bind the server to")
     args = parser.parse_args()
 
-    global loaded_config
-    enhance_config_from_env(loaded_config)
+    try:
+        default_config = _build_default_config()
+        _enhance_config_from_env(default_config)
+        if not _has_credentials(default_config):
+            raise ValueError(
+                "No Gemini credentials configured. Set GEMINI_API_KEY "
+                "(AI Studio) or GOOGLE_GENAI_USE_VERTEXAI=True + "
+                "GOOGLE_CLOUD_{PROJECT,LOCATION} (Vertex AI)."
+            )
+    except ValueError as e:
+        # Single startup-config exit point.
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
 
     # This is a hack, on Agent Substrate /etc/hosts end up not
     # having this entry even if it's the OCI image.
-    resolve_localhost()
+    _resolve_localhost()
         
-    asyncio.run(serve(args.host, args.port))
+    asyncio.run(_serve(args.host, args.port, default_config))
 
 if __name__ == "__main__":
     main()

--- a/python/antigravity/harness_server_test.py
+++ b/python/antigravity/harness_server_test.py
@@ -16,22 +16,19 @@ import asyncio
 import pytest
 import grpc
 from python.proto import ax_pb2, ax_pb2_grpc, content_pb2
-from python.antigravity.harness_server import AntigravityHarnessServiceServicer, loaded_config
+from python.antigravity.harness_server import AntigravityHarnessServiceServicer
 from google.antigravity import LocalAgentConfig
 
 @pytest.fixture
 def mock_config(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "mock-api-key")
-    cfg = LocalAgentConfig(system_instructions="Test instructions")
-    import python.antigravity.harness_server as hs
-    hs.loaded_config = cfg
-    return cfg
+    return LocalAgentConfig(system_instructions="Test instructions")
 
 def test_grpc_connect_success(mock_config, monkeypatch):
     async def _run():
         # 1. Start temporary local gRPC server on random open port
         server = grpc.aio.server()
-        servicer = AntigravityHarnessServiceServicer()
+        servicer = AntigravityHarnessServiceServicer(mock_config)
         ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
         port = server.add_insecure_port("localhost:0")
         await server.start()
@@ -99,7 +96,7 @@ def test_grpc_connect_success(mock_config, monkeypatch):
 def test_grpc_connect_agent_reused(mock_config, monkeypatch):
     async def _run():
         server = grpc.aio.server()
-        servicer = AntigravityHarnessServiceServicer()
+        servicer = AntigravityHarnessServiceServicer(mock_config)
         ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
         port = server.add_insecure_port("localhost:0")
         await server.start()
@@ -188,8 +185,9 @@ def test_health_check():
     async def _run():
         from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
+        cfg = LocalAgentConfig(system_instructions="health-check stub")
         server = grpc.aio.server()
-        ax_pb2_grpc.add_HarnessServiceServicer_to_server(AntigravityHarnessServiceServicer(), server)
+        ax_pb2_grpc.add_HarnessServiceServicer_to_server(AntigravityHarnessServiceServicer(cfg), server)
         health_servicer = health.aio.HealthServicer()
         health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
         await health_servicer.set("", health_pb2.HealthCheckResponse.SERVING)
@@ -206,51 +204,45 @@ def test_health_check():
     asyncio.run(_run())
 
 
-def test_grpc_connect_missing_credentials(mock_config, monkeypatch):
+def test_has_credentials_missing(monkeypatch):
+    """Returns False when neither env nor config provides credentials."""
+    from python.antigravity.harness_server import _has_credentials
+
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
     monkeypatch.delenv("GOOGLE_GENAI_USE_ENTERPRISE", raising=False)
 
-    async def _run():
-        server = grpc.aio.server()
-        servicer = AntigravityHarnessServiceServicer()
-        ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
-        port = server.add_insecure_port("localhost:0")
-        await server.start()
-        
-        addr = f"localhost:{port}"
-        async with grpc.aio.insecure_channel(addr) as channel:
-            stub = ax_pb2_grpc.HarnessServiceStub(channel)
-            
-            start_payload = ax_pb2.HarnessStart(
-                messages=[
-                    ax_pb2.Message(role="user", content=content_pb2.Content(text=content_pb2.TextContent(text="Hi")))
-                ]
-            )
-            req = ax_pb2.HarnessRequest(
-                conversation_id="conv-test-credentials",
-                harness_id="antigravity",
-                start=start_payload
-            )
-            
-            async def request_iter():
-                yield req
+    cfg = LocalAgentConfig(system_instructions="test")
+    assert _has_credentials(cfg) is False
 
-            responses = []
-            async for resp in stub.Connect(request_iter()):
-                responses.append(resp)
-                
-            assert len(responses) == 1
-            assert responses[0].WhichOneof('type') == 'end'
-            assert responses[0].end.state == ax_pb2.STATE_FAILED
-            assert responses[0].end.error.code == 9
-            assert "No Gemini credentials configured" in responses[0].end.error.description
-            assert "GEMINI_API_KEY" in responses[0].end.error.description
-            
-        await server.stop(0)
 
-    asyncio.run(_run())
+def test_has_credentials_vertex_requires_project_and_location(monkeypatch):
+    """vertex=True alone is not enough; AGY requires project+location too."""
+    from python.antigravity.harness_server import _has_credentials
+
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    cfg_vertex_only = LocalAgentConfig(system_instructions="test", vertex=True)
+    assert _has_credentials(cfg_vertex_only) is False
+
+    cfg_vertex_proj_only = LocalAgentConfig(system_instructions="test", vertex=True, project="p")
+    assert _has_credentials(cfg_vertex_proj_only) is False
+
+    cfg_vertex_loc_only = LocalAgentConfig(system_instructions="test", vertex=True, location="us-central1")
+    assert _has_credentials(cfg_vertex_loc_only) is False
+
+    cfg_vertex_full = LocalAgentConfig(system_instructions="test", vertex=True, project="p", location="us-central1")
+    assert _has_credentials(cfg_vertex_full) is True
+
+
+def test_has_credentials_vertex_express_mode(monkeypatch):
+    """vertex=True + api_key (Express Mode) is accepted even without project/location."""
+    from python.antigravity.harness_server import _has_credentials
+
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    cfg = LocalAgentConfig(system_instructions="test", vertex=True, api_key="express-key")
+    assert _has_credentials(cfg) is True
 
 
 def test_grpc_connect_programmatic_credentials(monkeypatch):
@@ -261,12 +253,10 @@ def test_grpc_connect_programmatic_credentials(monkeypatch):
 
     # Config with API key programmatically set
     cfg = LocalAgentConfig(system_instructions="Test instructions", api_key="mock-config-api-key")
-    import python.antigravity.harness_server as hs
-    hs.loaded_config = cfg
 
     async def _run():
         server = grpc.aio.server()
-        servicer = AntigravityHarnessServiceServicer()
+        servicer = AntigravityHarnessServiceServicer(cfg)
         ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
         port = server.add_insecure_port("localhost:0")
         await server.start()
@@ -325,7 +315,7 @@ def test_grpc_connect_programmatic_credentials(monkeypatch):
 
 
 def test_enhance_config_from_env(monkeypatch, tmp_path):
-    from python.antigravity.harness_server import enhance_config_from_env
+    from python.antigravity.harness_server import _enhance_config_from_env
     from google.antigravity import LocalAgentConfig
     import os
     
@@ -337,14 +327,14 @@ def test_enhance_config_from_env(monkeypatch, tmp_path):
     
     # Test: Using SKILLS_DIR env var
     monkeypatch.setenv("SKILLS_DIR", str(skills_dir))
-    enhance_config_from_env(cfg)
+    _enhance_config_from_env(cfg)
     assert str(skills_dir) in cfg.skills_paths
 
 
 def test_grpc_connect_buffering(mock_config, monkeypatch):
     async def _run():
         server = grpc.aio.server()
-        servicer = AntigravityHarnessServiceServicer()
+        servicer = AntigravityHarnessServiceServicer(mock_config)
         ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
         port = server.add_insecure_port("localhost:0")
         await server.start()
@@ -423,4 +413,115 @@ def test_grpc_connect_buffering(mock_config, monkeypatch):
 
     asyncio.run(_run())
 
+def test_vertex_kwargs_from_env_returns_kwargs(monkeypatch):
+    """GOOGLE_GENAI_USE_VERTEXAI + GOOGLE_CLOUD_{PROJECT,LOCATION} -> kwargs dict."""
+    from python.antigravity.harness_server import _vertex_kwargs_from_env
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "True")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-east1")
+    assert _vertex_kwargs_from_env() == {
+        "vertex": True,
+        "project": "env-project",
+        "location": "us-east1",
+    }
+
+
+def test_vertex_kwargs_from_env_no_op_without_vertex(monkeypatch):
+    """Without GOOGLE_GENAI_USE_VERTEXAI, returns empty dict."""
+    from python.antigravity.harness_server import _vertex_kwargs_from_env
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+    monkeypatch.delenv("GOOGLE_GENAI_USE_ENTERPRISE", raising=False)
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "should-be-ignored")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "should-be-ignored")
+    assert _vertex_kwargs_from_env() == {}
+
+
+def test_vertex_kwargs_from_env_raises_when_project_missing(monkeypatch):
+    """Vertex requested with no project -> ValueError naming the env var."""
+    from python.antigravity.harness_server import _vertex_kwargs_from_env
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "True")
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-east1")
+    with pytest.raises(ValueError, match="GOOGLE_CLOUD_PROJECT"):
+        _vertex_kwargs_from_env()
+
+
+def test_vertex_kwargs_from_env_raises_when_location_missing(monkeypatch):
+    """Vertex requested with no location -> ValueError naming the env var."""
+    from python.antigravity.harness_server import _vertex_kwargs_from_env
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "True")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+    monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
+    with pytest.raises(ValueError, match="GOOGLE_CLOUD_LOCATION"):
+        _vertex_kwargs_from_env()
+
+
+def test_vertex_kwargs_from_env_enterprise_alias(monkeypatch):
+    """GOOGLE_GENAI_USE_ENTERPRISE is an alias for VERTEXAI."""
+    from python.antigravity.harness_server import _vertex_kwargs_from_env
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+    monkeypatch.setenv("GOOGLE_GENAI_USE_ENTERPRISE", "true")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "ent-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+    assert _vertex_kwargs_from_env() == {
+        "vertex": True,
+        "project": "ent-project",
+        "location": "us-central1",
+    }
+
+
+def test_build_default_config_picks_up_vertex_env(monkeypatch):
+    """End-to-end: env vars flow through _build_default_config into LocalAgentConfig."""
+    from python.antigravity.harness_server import _build_default_config
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "True")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-east1")
+    cfg = _build_default_config()
+    assert cfg.vertex is True
+    assert cfg.project == "env-project"
+    assert cfg.location == "us-east1"
+
+
+def test_servicer_requires_default_config():
+    """Constructor takes a default config; passing nothing is a TypeError."""
+    with pytest.raises(TypeError, match="default_config"):
+        AntigravityHarnessServiceServicer()
+
+
+def test_run_turn_guards_against_missing_default_config(monkeypatch):
+    """If something sets _default_config to None at runtime (future bug in
+    per-request layering, #194), _run_turn returns STATE_FAILED instead of
+    crashing the server.
+    """
+    async def _run():
+        cfg = LocalAgentConfig(system_instructions="will be set to None")
+        servicer = AntigravityHarnessServiceServicer(cfg)
+        servicer._default_config = None
+        server = grpc.aio.server()
+        ax_pb2_grpc.add_HarnessServiceServicer_to_server(servicer, server)
+        port = server.add_insecure_port("localhost:0")
+        await server.start()
+        try:
+            async with grpc.aio.insecure_channel(f"localhost:{port}") as channel:
+                stub = ax_pb2_grpc.HarnessServiceStub(channel)
+                req = ax_pb2.HarnessRequest(
+                    conversation_id="conv-guard",
+                    harness_id="antigravity",
+                    start=ax_pb2.HarnessStart(messages=[
+                        ax_pb2.Message(role="user",
+                            content=content_pb2.Content(text=content_pb2.TextContent(text="Hi"))),
+                    ]),
+                )
+                async def request_iter():
+                    yield req
+                responses = []
+                async for resp in stub.Connect(request_iter()):
+                    responses.append(resp)
+                assert len(responses) == 1
+                assert responses[0].end.state == ax_pb2.STATE_FAILED
+                assert responses[0].end.error.code == 9
+                assert "Agent config is not loaded" in responses[0].end.error.description
+        finally:
+            await server.stop(0)
+    asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
The README documents `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` / `GOOGLE_GENAI_USE_VERTEXAI=True` as the way to run the antigravity sidecar against Vertex AI, but the AGY SDK does not read these env vars — it requires `vertex`/`project`/`location` explicitly on `LocalAgentConfig`. After [#177](https://github.com/google/ax/pull/177) bumped to `google-antigravity==0.1.5` (which restructured the config API), this surfaces as: user sets all 3 documented env vars → `ax exec` fails per-request with `A Gemini API key is required.`

This PR makes the sidecar read those env vars at startup and pass them to `LocalAgentConfig.__init__` so AGY's `@model_validator` picks them up. Also moves credential validation from per-request to startup with a single exit point in `main()` for symmetry with the vertex env validation.

## Why pass to `__init__` rather than mutate
AGY's `_apply_shorthand_configs` runs once at construction (as a `@pydantic.model_validator(mode="after")`). Post-init mutation of `config.{vertex,project,location}` does NOT regenerate `config.models`, so AGY's per-endpoint `validate_endpoint()` still sees the default `GeminiAPIEndpoint(api_key=None)` and rejects the request. Passing via `__init__(**_vertex_kwargs_from_env())` lets the validator generate the correct `VertexEndpoint(project=..., location=...)`.

## Changes
- `python/antigravity/harness_server.py`:
  - New `_env_use_vertex()` helper (env flag check).
  - New `_vertex_kwargs_from_env()` — returns `dict` of `{vertex, project, location}` from env, or `{}` if env doesn't request Vertex. Raises `ValueError` if Vertex requested but project/location missing.
  - `_build_default_config()` calls `LocalAgentConfig(..., **_vertex_kwargs_from_env())` so env values flow through AGY's `__init__` validators.
  - `_has_credentials` rewritten to mirror AGY's per-endpoint validation: only `GEMINI_API_KEY` env, `config.api_key`, or `config.vertex=True + config.{project,location}` (dropped `GOOGLE_API_KEY` and per-model api_keys; AGY doesn't accept them).
  - Credential check moved from per-request (`_run_turn`) to startup (`main`); single try/except in `main()` is the only exit point — helpers raise `ValueError`, `main` prints `ERROR: ...` to stderr and exits 1.
  - Replaced `loaded_config` module global with `_build_default_config()` factory injected into the servicer constructor. TODOs mark where #194's per-request `harness_config` layering will plug in.
  - Renamed module-private helpers to `_`-prefix (`_serve`, `_enhance_config_from_env`, `_resolve_localhost`).
- `python/antigravity/harness_server_test.py`:
  - 6 vertex env tests + 1 end-to-end `_build_default_config_picks_up_vertex_env` test + 2 credential tests (vertex requires project+location; Express Mode) + 2 servicer DI tests.
  - Existing tests updated to inject config via constructor (no module-global mutation).

## Verification

**Unit tests:** 17/17 pass against `google-antigravity==0.1.5` (current PyPI wheel, uploaded 2026-06-25). `go build` + `go test`: clean.

**End-to-end via `ax exec` → `ax serve` → sidecar → AGY → Vertex AI:**

| Scenario | Env | Result |
|---|---|---|
| Vertex happy path | `GOOGLE_GENAI_USE_VERTEXAI=True` + `GOOGLE_CLOUD_PROJECT=cloud-ai-agentic-coding` + `GOOGLE_CLOUD_LOCATION=global` | Sidecar boots: `Vertex AI backend configured: project=... location=...`. `ax exec "capital of France?"` → real Vertex/Gemini response: `Paris is the capital of France.` |
| Vertex + missing PROJECT | `GOOGLE_GENAI_USE_VERTEXAI=True` + `GOOGLE_CLOUD_LOCATION=us-east1` | Exits 1 at startup: `ERROR: Vertex AI backend requested but missing required config: project (set GOOGLE_CLOUD_PROJECT)` |
| No credentials | (none) | Exits 1 at startup: `ERROR: No Gemini credentials configured. Set GEMINI_API_KEY (AI Studio) or GOOGLE_GENAI_USE_VERTEXAI=True + GOOGLE_CLOUD_{PROJECT,LOCATION} (Vertex AI).` |

Sidecar log: `[gRPC] Running chat query` → `[gRPC] Turn completed successfully`. No mocked-tool involvement — response is real model output from Vertex AI.

## Out of scope
- Per-request `harness_config` layering (#194) — TODO markers placed.
- Substrate path: deployed via baked image / actor template, no env forwarding needed.

Closes #225.