### PR TITLE
Change bucket var name and bump substrate version.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.3
-	github.com/agent-substrate/substrate v0.0.0-20260622205654-fe93d160a1df
+	github.com/agent-substrate/substrate v0.0.0-20260629215754-fe48750deb27
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/agent-substrate/substrate v0.0.0-20260622205654-fe93d160a1df h1:Qq7cujws6kbtE/ykSlCBcZQWlpK/HQQZcmbUjJbWiUs=
-github.com/agent-substrate/substrate v0.0.0-20260622205654-fe93d160a1df/go.mod h1:TgdtEUV6iaflJTwmS8ONiGsyyJD+5okPZj2H6mM8WlA=
+github.com/agent-substrate/substrate v0.0.0-20260629215754-fe48750deb27 h1:REbnncRlgoNQYIHMRm9Gu/3KQReTPQVWRn6A5jZM/GQ=
+github.com/agent-substrate/substrate v0.0.0-20260629215754-fe48750deb27/go.mod h1:2ri5mTz714LWinayPQG1d4G/kMuzbqvRXlrUrpc7N9Y=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=

--- a/hack/install-ax.sh
+++ b/hack/install-ax.sh
@@ -192,12 +192,12 @@ deploy_ax_server() {
     echo "Error: GEMINI_API_KEY environment variable must be set" >&2
     exit 1
   fi
-  if [[ -z "${BUCKET_NAME:-}" ]]; then
-    echo "Error: BUCKET_NAME environment variable must be set" >&2
+  if [[ -z "${AX_SNAPSHOTS_BUCKET:-}" ]]; then
+    echo "Error: AX_SNAPSHOTS_BUCKET environment variable must be set" >&2
     exit 1
   fi
 
-  echo "Using GCS Bucket: ${BUCKET_NAME}"
+  echo "Using GCS Bucket: ${AX_SNAPSHOTS_BUCKET}"
 
   # Build and push the images, capturing their digest-pinned references.
   local ax_image ateom_image
@@ -216,7 +216,7 @@ deploy_ax_server() {
 
   # Render the manifest and apply it.
   if ! sed -e "s|\${GEMINI_API_KEY}|${GEMINI_API_KEY}|g" \
-      -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
+      -e "s|\${AX_SNAPSHOTS_BUCKET}|${AX_SNAPSHOTS_BUCKET}|g" \
       -e "s|\${AX_IMAGE}|${ax_image}|g" \
       -e "s|\${ATEOM_IMAGE}|${ateom_image}|g" \
       -e "s|\${POSTGRES_PASSWORD}|${pg_password}|g" \

--- a/internal/harness/mocks_test.go
+++ b/internal/harness/mocks_test.go
@@ -50,29 +50,33 @@ type mockControlServer struct {
 	resumeNilActor bool   // when true, ResumeActor returns a nil Actor
 }
 
+func (f *mockControlServer) CreateAtespace(_ context.Context, req *ateapipb.CreateAtespaceRequest) (*ateapipb.CreateAtespaceResponse, error) {
+	return &ateapipb.CreateAtespaceResponse{Atespace: &ateapipb.Atespace{Name: req.GetName()}}, nil
+}
+
 func (f *mockControlServer) CreateActor(_ context.Context, req *ateapipb.CreateActorRequest) (*ateapipb.CreateActorResponse, error) {
 	f.mu.Lock()
-	f.createCalls = append(f.createCalls, req.GetActorId())
+	f.createCalls = append(f.createCalls, req.GetActorRef().GetName())
 	f.mu.Unlock()
 	if f.createErr != nil {
 		return nil, f.createErr
 	}
-	return &ateapipb.CreateActorResponse{Actor: &ateapipb.Actor{ActorId: req.GetActorId()}}, nil
+	return &ateapipb.CreateActorResponse{Actor: &ateapipb.Actor{ActorId: req.GetActorRef().GetName()}}, nil
 }
 
 func (f *mockControlServer) ResumeActor(_ context.Context, req *ateapipb.ResumeActorRequest) (*ateapipb.ResumeActorResponse, error) {
 	f.mu.Lock()
-	f.resumeCalls = append(f.resumeCalls, req.GetActorId())
+	f.resumeCalls = append(f.resumeCalls, req.GetActorRef().GetName())
 	f.mu.Unlock()
 	if f.resumeNilActor {
 		return &ateapipb.ResumeActorResponse{}, nil
 	}
-	return &ateapipb.ResumeActorResponse{Actor: &ateapipb.Actor{ActorId: req.GetActorId(), AteomPodIp: f.resumeIP}}, nil
+	return &ateapipb.ResumeActorResponse{Actor: &ateapipb.Actor{ActorId: req.GetActorRef().GetName(), AteomPodIp: f.resumeIP}}, nil
 }
 
 func (f *mockControlServer) SuspendActor(_ context.Context, req *ateapipb.SuspendActorRequest) (*ateapipb.SuspendActorResponse, error) {
 	f.mu.Lock()
-	f.suspendCalls = append(f.suspendCalls, req.GetActorId())
+	f.suspendCalls = append(f.suspendCalls, req.GetActorRef().GetName())
 	f.mu.Unlock()
 	return &ateapipb.SuspendActorResponse{}, nil
 }

--- a/internal/k8s/ate/client.go
+++ b/internal/k8s/ate/client.go
@@ -21,7 +21,9 @@ import (
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 type Client struct {
@@ -58,8 +60,11 @@ func NewClient(ns, template, target string, opts ...grpc.DialOption) (*Client, e
 // CreateActor creates a new actor.
 func (c *Client) CreateActor(ctx context.Context, id string) (*ateapipb.CreateActorResponse, error) {
 	client := ateapipb.NewControlClient(c.conn)
+	if _, err := client.CreateAtespace(ctx, &ateapipb.CreateAtespaceRequest{Name: c.namespace}); err != nil && status.Code(err) != codes.AlreadyExists {
+		return nil, fmt.Errorf("error when calling Control.CreateAtespace: %w", err)
+	}
 	resp, err := client.CreateActor(ctx, &ateapipb.CreateActorRequest{
-		ActorId:                id,
+		ActorRef:               &ateapipb.ActorRef{Atespace: c.namespace, Name: id},
 		ActorTemplateNamespace: c.namespace,
 		ActorTemplateName:      c.template,
 	})
@@ -74,7 +79,7 @@ func (c *Client) CreateActor(ctx context.Context, id string) (*ateapipb.CreateAc
 func (c *Client) ResumeActor(ctx context.Context, id string) (*ateapipb.ResumeActorResponse, error) {
 	client := ateapipb.NewControlClient(c.conn)
 	resp, err := client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-		ActorId: id,
+		ActorRef: &ateapipb.ActorRef{Atespace: c.namespace, Name: id},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when calling Control.ResumeActor: %w", err)
@@ -86,7 +91,7 @@ func (c *Client) ResumeActor(ctx context.Context, id string) (*ateapipb.ResumeAc
 func (c *Client) SuspendActor(ctx context.Context, id string) (*ateapipb.SuspendActorResponse, error) {
 	client := ateapipb.NewControlClient(c.conn)
 	resp, err := client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{
-		ActorId: id,
+		ActorRef: &ateapipb.ActorRef{Atespace: c.namespace, Name: id},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when calling Control.SuspendActor: %w", err)

--- a/internal/k8s/ate/client.go
+++ b/internal/k8s/ate/client.go
@@ -60,6 +60,7 @@ func NewClient(ns, template, target string, opts ...grpc.DialOption) (*Client, e
 // CreateActor creates a new actor.
 func (c *Client) CreateActor(ctx context.Context, id string) (*ateapipb.CreateActorResponse, error) {
 	client := ateapipb.NewControlClient(c.conn)
+	// TODO(wjjclaud): Configure atespace in manifests instead of reusing the namespace.
 	if _, err := client.CreateAtespace(ctx, &ateapipb.CreateAtespaceRequest{Name: c.namespace}); err != nil && status.Code(err) != codes.AlreadyExists {
 		return nil, fmt.Errorf("error when calling Control.CreateAtespace: %w", err)
 	}

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -18,7 +18,7 @@ The target Kubernetes cluster is assumed to have
 ### 1. Build and Deploy
 
 > [!NOTE]
-> Do not manually edit `manifests/ax-deployment.yaml`. The installation script automatically injects your `${GEMINI_API_KEY}`, `${BUCKET_NAME}`, and the built `${AX_IMAGE}` and `${ATEOM_IMAGE}` references during deployment.
+> Do not manually edit `manifests/ax-deployment.yaml`. The installation script automatically injects your `${GEMINI_API_KEY}`, `${AX_SNAPSHOTS_BUCKET}`, and the built `${AX_IMAGE}` and `${ATEOM_IMAGE}` references during deployment.
 
 The installation script builds the required images and applies the resolved
 manifests to your cluster:
@@ -59,7 +59,7 @@ gcloud auth configure-docker   # set up the gcr.io credential helper
 ```bash
 export PROJECT_ID="ax-substrate" # Your GCP project ID
 export GEMINI_API_KEY="your-api-key"
-export BUCKET_NAME="snapshot-substrate-test-$PROJECT_ID"
+export AX_SNAPSHOTS_BUCKET="snapshot-substrate-test-$PROJECT_ID"
 
 ./hack/install-ax.sh --deploy-ax-server
 ```

--- a/manifests/ax-deployment.yaml
+++ b/manifests/ax-deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - name: AX_HARNESS_WORKDIR
           value: "/ax"
   snapshotsConfig:
-    location: gs://${BUCKET_NAME}/antigravity/
+    location: gs://${AX_SNAPSHOTS_BUCKET}/antigravity/
 ---
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Rename Env var `BUCKET_NAME` → `AX_SNAPSHOTS_BUCKET` Fix #219.
- Bump substrate version and update client with new schema.

Note: Developers need to update their substrate to the pinned version after this PR. 