### PR TITLE
Fix spacing between AGY harness responses

### DIFF
--- a/cmd/ax/internal/display.go
+++ b/cmd/ax/internal/display.go
@@ -106,7 +106,14 @@ func (d *Display) Display(content *proto.Content) {
 		// Let the confirmation prompt handle displaying the question.
 
 	case *proto.Content_ToolCall:
-		// No-op for cleaner CLI logs
+		// Tool calls aren't rendered, but they mark a boundary between
+		// contiguous text/thought blocks. Terminate the current line so the
+		// next response starts fresh instead of running into the previous one
+		// (e.g. "...configured.I will list...").
+		if d.state != stateNone {
+			fmt.Fprintln(d.w)
+			d.state = stateNone
+		}
 
 	case *proto.Content_ToolResult:
 		// Only print if the tool returned an error, otherwise skip

--- a/cmd/ax/internal/display_test.go
+++ b/cmd/ax/internal/display_test.go
@@ -32,6 +32,9 @@ func TestDisplay_Streaming(t *testing.T) {
 			},
 		}}}
 	}
+	toolCallContent := func() *proto.Content {
+		return &proto.Content{Type: &proto.Content_ToolCall{ToolCall: &proto.ToolCallContent{}}}
+	}
 
 	t.Run("consecutive text chunks are concatenated", func(t *testing.T) {
 		t.Parallel()
@@ -44,6 +47,39 @@ func TestDisplay_Streaming(t *testing.T) {
 
 		got := buf.String()
 		want := "Hello world!"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("tool call separates consecutive text blocks", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		d := NewDisplay("test-id", &buf)
+
+		d.Display(textContent("...configured."))
+		d.Display(toolCallContent())
+		d.Display(textContent("I will list the contents."))
+
+		got := buf.String()
+		want := "...configured.\nI will list the contents."
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("repeated tool calls do not add extra newlines", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		d := NewDisplay("test-id", &buf)
+
+		d.Display(textContent("Done."))
+		d.Display(toolCallContent())
+		d.Display(toolCallContent())
+		d.Display(textContent("Next."))
+
+		got := buf.String()
+		want := "Done.\nNext."
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}


### PR DESCRIPTION
The AGY harness streams each contiguous block of assistant text as a separate TextContent message, with tool calls in between. The CLI display (cmd/ax/internal/display.go) tracks a state field to decide when to insert separating newlines  but the Content_ToolCall case was a pure no-op that left state == stateText.

Fixes #233.