### PR TITLE
harness/python: normalize thought summary whitespace (#191)

### DIFF
--- a/python/antigravity/harness_server.py
+++ b/python/antigravity/harness_server.py
@@ -21,6 +21,7 @@ import argparse
 import asyncio
 import logging
 import os
+import re
 import sys
 from typing import TypedDict
 import grpc
@@ -258,8 +259,19 @@ class AntigravityHarnessServiceServicer(ax_pb2_grpc.HarnessServiceServicer):
             def flush_thought():
                 if not thought_chunks:
                     return None
+
+                # Normalize Gemini's thinking output: collapse runs of 3+ newlines
+                # (emitted between reasoning sections) to exactly one blank line
+                # and strip trailing whitespace. Then append exactly one trailing
+                # newline so downstream displays render a blank line between the
+                # thinking block and whatever follows (next thought, tool call,
+                # or answer text). Without the trailing newline the display's
+                # transition logic emits only one newline, gluing blocks together.
+                raw_text = "".join(thought_chunks)
+                clean_text = re.sub(r'\n{3,}', '\n\n', raw_text).rstrip() + '\n'
+
                 summary = [
-                    content_pb2.ThoughtSummaryContent(text=content_pb2.TextContent(text="".join(thought_chunks)))
+                    content_pb2.ThoughtSummaryContent(text=content_pb2.TextContent(text=clean_text))
                 ]
                 thought_chunks.clear()
                 msg = ax_pb2.Message(


### PR DESCRIPTION
Fixes #191.

## Context

Gemini's thinking summaries contain runs of `\n\n\n` between reasoning
sections and often trailing `\n\n`. Previously, the Python AGY harness
streamed these payloads verbatim over gRPC to the AX controller. This
meant every downstream client (`cmd/ax/internal/display.go`, the Web
Dashboard, and any future one) would need to know to scrub Gemini's
particular whitespace quirks.

## Fix

Normalize the payload in the Python harness adapter — the same layer
already responsible for shielding downstream clients from
model/SDK-specific representations. In `flush_thought()`:

1. Collapse runs of 3+ newlines to a single blank line (`\n{3,}` → `\n\n`).
2. `rstrip()` trailing whitespace so the payload doesn't leak trailing
   newlines into downstream renderers.
3. Append exactly one trailing newline so downstream displays render
   a blank line between the thinking block and whatever follows (next
   thought, tool call, or answer text). Without this, `display.go`'s
   single-newline transition would glue blocks together.

## End-to-end validation

Verified against a live `ax exec --harness antigravity` with a real
Vertex AI Gemini backend. Sample output:

```
⏺ what's the weather in New York City

Thinking: **Searching Web for Data**

I'm currently focusing on acquiring the necessary weather data for New York City. Since I lack a direct tool, I'm preparing to utilize the `search_web` function to locate this information.

**Exploring Web Search Options**

I'm focusing on how to best retrieve New York City weather data. As I don't have a dedicated weather tool, I'll be employing the `search_web` function. My initial query will be "weather in New York City."

Thinking: **Finding Weather Forecasts**

I've successfully retrieved the New York City weather forecast using my search capabilities. I can now present these details to you.

**Presenting Weather Data**

I've successfully gathered the New York City weather forecast and am now ready to share the detailed information with you.

It is currently raining in New York City with a temperature of 69°F (21°C)...
```

- Single blank line between reasoning sections within a `Thinking:` block ✓
- Single blank line between consecutive `Thinking:` blocks ✓
- Single blank line between the last `Thinking:` block and the answer text ✓
- No runs of 2+ blank lines anywhere ✓

Compare to the buggy output in the issue where blank-line runs appeared
in all three positions.

## Alternatives considered

* **Do the normalization in `cmd/ax/internal/display.go`.** Rejected
  per Jaana's review: it would put model/SDK-specific whitespace
  quirks into a generic renderer, and would need to be duplicated in
  every other client (Web Dashboard, etc.). PR #239 handles
  *structural* boundary spacing (between different `Content` types)
  in the display, which is appropriate; but payload cleanup belongs
  in the adapter.
* **Rely on the AGY SDK to normalize.** The SDK documents
  `thinking_delta` as a raw incremental substring, so a lossy
  normalization there would break the SDK's contract for other
  consumers.
* **Skip the trailing `+ '\n'` and let display handle separation.**
  Live testing revealed this glues consecutive thinking blocks
  together (no blank line between them) because `display.go`'s
  thought-transition logic emits only one `\n`. The trailing newline
  produces the correct rendering with today's display code; if
  display ownership of the transition changes later, the harness
  contract can be revised.