### PR TITLE
Use /axharness folder in the snapshots bucket

### DIFF
--- a/manifests/ax-deployment.yaml
+++ b/manifests/ax-deployment.yaml
@@ -72,7 +72,7 @@ spec:
           path: /readyz
           port: 8081
   snapshotsConfig:
-    location: gs://${AX_SNAPSHOTS_BUCKET}/antigravity/
+    location: gs://${AX_SNAPSHOTS_BUCKET}/axharness/
 ---
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The ax harness server will provide more than Antigravity.

Depends on https://github.com/google/ax/pull/254.