### PR TITLE
Auto-start Antigravity Python sidecar from ax exec

### DIFF
--- a/cmd/ax/internal/cliutil/cliutil.go
+++ b/cmd/ax/internal/cliutil/cliutil.go
@@ -56,6 +56,12 @@ func NewControllerFromConfig(ctx context.Context, cfg *Config) (*controller.Cont
 	// substrate actors ("1").
 	substrateMode := os.Getenv("AX_SUBSTRATE") == "1"
 
+	// Validate config before local-mode antigravity.New forks the Python
+	// sidecar, so a config error surfaces without spawning a subprocess.
+	if len(cfg.Harnesses.Substrate) > 0 && !substrateMode {
+		return nil, fmt.Errorf("custom substrate harnesses require AX_SUBSTRATE=1")
+	}
+
 	// Built-in harnesses.
 	var defaultHarnessID string
 	var antigravityHarness harness.Harness
@@ -65,7 +71,11 @@ func NewControllerFromConfig(ctx context.Context, cfg *Config) (*controller.Cont
 		if address == "" {
 			address = "127.0.0.1:50053"
 		}
-		antigravityHarness = antigravity.New(address)
+		// Local mode: the harness owns the Python sidecar.
+		antigravityHarness, err = antigravity.New(ctx, address, true)
+		if err != nil {
+			return nil, fmt.Errorf("antigravity harness: %w", err)
+		}
 	} else {
 		antigravityHarness, err = substrate.New(antigravityHarnessID, "", "", "", 80)
 		if err != nil {
@@ -79,10 +89,6 @@ func NewControllerFromConfig(ctx context.Context, cfg *Config) (*controller.Cont
 		defaultHarnessID = antigravityHarnessID
 	}
 
-	// Custom substrate harnesses.
-	if len(cfg.Harnesses.Substrate) > 0 && !substrateMode {
-		return nil, fmt.Errorf("custom substrate harnesses require AX_SUBSTRATE=1")
-	}
 	for _, sc := range cfg.Harnesses.Substrate {
 		h, err := sc.NewHarness("")
 		if err != nil {

--- a/cmd/ax/internal/cliutil/cliutil_test.go
+++ b/cmd/ax/internal/cliutil/cliutil_test.go
@@ -23,31 +23,6 @@ import (
 	"github.com/google/ax/internal/config"
 )
 
-func TestNewControllerFromConfig_DefaultHarness(t *testing.T) {
-	cfg := &config.Config{
-		EventLog: config.EventLogConfig{
-			SQLiteConfig: config.SQLiteConfig{
-				Filename: filepath.Join(t.TempDir(), "log.sqlite"),
-			},
-		},
-		Harnesses: config.HarnessesConfig{
-			Antigravity: config.AntigravityHarnessConfig{
-				Default:  true,
-				Endpoint: "localhost:50053",
-			},
-		},
-	}
-
-	c, err := NewControllerFromConfig(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("NewControllerFromConfig: %v", err)
-	}
-	if c == nil {
-		t.Fatal("expected non-nil controller")
-	}
-	c.Close()
-}
-
 func TestNewControllerFromConfig_BuiltinSubstrate(t *testing.T) {
 	t.Setenv("AX_SUBSTRATE", "1")
 

--- a/internal/cmd/e2e/main.go
+++ b/internal/cmd/e2e/main.go
@@ -74,7 +74,8 @@ func main() {
 		}
 		conn.Close()
 		fmt.Printf("Connected to Antigravity gRPC harness server at %s\n", address)
-		h := antigravity.New(address)
+		// TODO: add a companion demo that uses autoStart=true (mirrors ax exec local mode).
+		h, _ := antigravity.New(ctx, address, false)
 		reg.RegisterHarness("antigravity", h)
 	})
 }

--- a/internal/harness/antigravity/antigravity.go
+++ b/internal/harness/antigravity/antigravity.go
@@ -18,7 +18,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
@@ -26,6 +30,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/google/ax/internal/harness"
+	"github.com/google/ax/internal/pythonsidecar"
 	"github.com/google/ax/proto"
 	"github.com/google/uuid"
 )
@@ -38,17 +43,49 @@ var _ harness.Execution = (*antigravityExecution)(nil)
 // Antigravity Python agent server over gRPC.
 type AntigravityHarness struct {
 	address string
+	sidecar *pythonsidecar.Sidecar // non-nil when this harness forked the process
 }
 
-// New creates a new AntigravityHarness with a configurable address.
-// Address defaults to "127.0.0.1:50053" (gRPC TCP connection).
-func New(address string) *AntigravityHarness {
+// New creates a new AntigravityHarness. When autoStart is true, New forks the
+// Antigravity Python sidecar and waits for it to become reachable.
+func New(ctx context.Context, address string, autoStart bool) (*AntigravityHarness, error) {
 	if address == "" {
 		address = "127.0.0.1:50053"
 	}
-	return &AntigravityHarness{
-		address: address,
+	h := &AntigravityHarness{address: address}
+	if !autoStart {
+		return h, nil
 	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("antigravity: invalid address %q: %w", address, err)
+	}
+	cfg := pythonsidecar.Config{
+		Module: "python.antigravity.harness_server",
+		Args: []string{
+			"--host", host,
+			"--port", port,
+		},
+		Stdin:     os.Stdin,
+		Stdout:    os.Stdout,
+		Stderr:    os.Stderr,
+		ReadyFunc: pythonsidecar.TCPReady(address),
+	}
+	sidecar := pythonsidecar.New(cfg)
+	if err := sidecar.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start antigravity harness server: %w", err)
+	}
+	h.sidecar = sidecar
+	// Own the sidecar lifecycle here (no registry->controller->antigravity
+	// teardown chain): on ctrl-C / SIGTERM, stop the Python process
+	// directly. Mirrors cmd/ax/harness.go.
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		_ = sidecar.Stop()
+	}()
+	return h, nil
 }
 
 // Start implements Harness.Start.

--- a/internal/harness/antigravity/antigravity_test.go
+++ b/internal/harness/antigravity/antigravity_test.go
@@ -17,6 +17,10 @@ package antigravity
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -26,11 +30,14 @@ import (
 
 var antigravityHarnessConfig = []byte(`{"system_instructions":"be terse"}`)
 
-func TestAntigravityHarness_Run_Success(t *testing.T) {
+func TestRun_AutoStartFalse_ServerOK_Succeeds(t *testing.T) {
 	srv := &harnesstest.MockHarnessServer{
 		Outputs: []*proto.Message{harnesstest.ThoughtText("Analyzing"), harnesstest.AssistantText("Hello world")},
 	}
-	harnessClient := New(harnesstest.StartHarnessServer(t, srv))
+	harnessClient, err := New(context.Background(), harnesstest.StartHarnessServer(t, srv), false)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 
 	exec, err := harnessClient.Start(context.Background(), "conv-test", antigravityHarnessConfig)
 	if err != nil {
@@ -70,9 +77,12 @@ func TestAntigravityHarness_Run_Success(t *testing.T) {
 	}
 }
 
-func TestAntigravityHarness_Run_ErrorFrame(t *testing.T) {
+func TestRun_AutoStartFalse_ServerErrorFrame_Fails(t *testing.T) {
 	srv := &harnesstest.MockHarnessServer{FailConnect: true, ErrMessage: "internal mock server crash"}
-	harnessClient := New(harnesstest.StartHarnessServer(t, srv))
+	harnessClient, err := New(context.Background(), harnesstest.StartHarnessServer(t, srv), false)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 
 	exec, _ := harnessClient.Start(context.Background(), "conv-test", antigravityHarnessConfig)
 	defer exec.Close(context.Background())
@@ -81,11 +91,78 @@ func TestAntigravityHarness_Run_ErrorFrame(t *testing.T) {
 		t.Fatalf("failed to queue message: %v", err)
 	}
 
-	err := exec.Run(context.Background(), &harnesstest.MockHandler{})
+	err = exec.Run(context.Background(), &harnesstest.MockHandler{})
 	if err == nil {
 		t.Fatal("expected error from Run(), got nil")
 	}
 	if !strings.Contains(err.Error(), "internal mock server crash") {
 		t.Errorf("unexpected error message: %v", err)
 	}
+}
+
+// TestNew_AutoStartFalse_NilSidecar: autoStart=false leaves sidecar nil.
+func TestNew_AutoStartFalse_NilSidecar(t *testing.T) {
+	h, err := New(context.Background(), "127.0.0.1:1", false)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if h.sidecar != nil {
+		t.Errorf("expected sidecar to be nil, got %v", h.sidecar)
+	}
+}
+
+// TestNew_AutoStartTrue_StubServer_ForksSidecar drives the real fork +
+// TCPReady path with a tiny stub python.antigravity.harness_server on
+// PYTHONPATH, so we don't need the AGY SDK installed to test the wiring.
+// sidecar.Stop stops the forked process.
+func TestNew_AutoStartTrue_StubServer_ForksSidecar(t *testing.T) {
+	stubPythonAntigravityModule(t)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", getFreePort(t))
+	h, err := New(context.Background(), addr, true)
+	if err != nil {
+		t.Fatalf("New(autoStart=true): %v", err)
+	}
+	if h.sidecar == nil {
+		t.Fatal("expected sidecar to be forked, got nil")
+	}
+	if !h.sidecar.IsRunning() {
+		t.Fatal("expected sidecar to be running after New")
+	}
+	if err := h.sidecar.Stop(); err != nil {
+		t.Errorf("sidecar.Stop: %v", err)
+	}
+	if h.sidecar.IsRunning() {
+		t.Error("expected sidecar to be stopped")
+	}
+}
+
+// stubPythonAntigravityModule writes a minimal python/antigravity/harness_server.py on PYTHONPATH that runs a stdlib socketserver.TCPServer so pythonsidecar.TCPReady succeeds without needing the real AGY SDK.
+func stubPythonAntigravityModule(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	pkg := filepath.Join(root, "python", "antigravity")
+	if err := os.MkdirAll(pkg, 0755); err != nil {
+		t.Fatalf("mkdir stub: %v", err)
+	}
+	src := `import socketserver, sys
+port = int(sys.argv[sys.argv.index("--port")+1])
+socketserver.TCPServer.allow_reuse_address = True
+socketserver.TCPServer(("127.0.0.1", port), socketserver.BaseRequestHandler).serve_forever()
+`
+	if err := os.WriteFile(filepath.Join(pkg, "harness_server.py"), []byte(src), 0644); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv("PYTHONPATH", root)
+}
+
+func getFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
 }


### PR DESCRIPTION
Progresses #249 (autofork done; PYTHONPATH & pip install still user responsibility — see Scope + Known limitation)

## Scope

This PR only wires the sidecar startup via `pythonsidecar`. It does **not** install the Python runtime dependencies of `python/antigravity/harness_server.py`. Users are expected to have them installed before running `ax exec`:

```
pip install -r python/antigravity/requirements.txt
```

## Known limitation: set `PYTHONPATH` before `ax exec`
Local users need to manually prepend the repo root and `python/` to `PYTHONPATH`:
```bash
export PYTHONPATH="$PWD:$PWD/python:$PYTHONPATH"
```
Without this, the sidecar fork fails with:
```
ImportError: cannot import name 'content_pb2' from 'proto' (unknown location)
```
**Root cause.** `harness_server.py` uses `from python.proto import ax_pb2` (needs repo root on `sys.path`) while generated `ax_pb2.py` uses `from proto import content_pb2` (needs `python/` on `sys.path`). Python's default `sys.path` satisfies only one. This has been the case since PR #34 introduced the streaming harness.
**Substrate is unaffected.** `cmd/ax/Dockerfile:64` sets `ENV PYTHONPATH=/ax-app:/ax-app/python`, so pods inherit it via the container image.
**Follow-up.** `go:embed`-ing `python/` into the ax binary and pointing `PYTHONPATH` at the extracted cache dir. Out of scope for this PR.

## Summary

`ax exec` now forks the Antigravity Python sidecar automatically via `pythonsidecar` (#273). Users no longer need to run `ax harness` in a separate terminal.

## Design rationale

This PR is intentionally minimal. An earlier attempt (#251, 1122 lines) shipped the full CUJ end-to-end — identity probe to distinguish AGY vs foreign sidecars, `Pdeathsig` for parent-crash cleanup, a shared autostart package for future harnesses, and an `AX_ANTIGRAVITY_NO_AUTOSTART` escape hatch. Post-review discussion converged on stacking the work as smaller PRs: land the minimum autofork here, add each capability as its own reviewable follow-up. This PR is that minimum. Known follow-ups (all `TODO`'d in code or tracked as issues):

- Reuse an existing AGY sidecar via a named gRPC health service identity probe (currently: any port-in-use fails the fork)
- Parent-crash cleanup (`Pdeathsig` on Linux)
- Auto PYTHONPATH via `go:embed` (#270 / addressed by #276)
- Auto `pip install` at first run

## API

- `antigravity.New(ctx, address, autoStart)` — when `autoStart=true`, forks the sidecar, waits for `TCPReady`, installs a signal handler that stops it on SIGINT/SIGTERM.
- `cliutil.NewControllerFromConfig` passes `autoStart=true` in local mode.

Substrate mode and the e2e demo pass `autoStart=false` (unchanged behavior).

## Tests
1. unit test 
2. manual run 

(.venv) lhuan@lhuan:~/ax-test$ ./ax exec --input "hi"
Starting gRPC harness server on 127.0.0.1:50053...
Conversation: 7b7974ff-0b58-445b-a836-ca41e3500f43

⏺ hi

[gRPC] Connect turn requested. conv_id=7b7974ff-0b58-445b-a836-ca41e3500f43
[gRPC] Creating new Agent instance for conv_id=7b7974ff-0b58-445b-a836-ca41e3500f43
[gRPC] Running chat query: hi
[gRPC] Turn completed successfully.
Hello! How can I help you today?
seq=2
