### PR TITLE
Antigravity interactions harness registry and config

### DIFF
--- a/ax.yaml
+++ b/ax.yaml
@@ -27,6 +27,9 @@ eventlog:
 harnesses:
   antigravity:
     default: true
+  # TODO(wjjclaud): Uncomment when ready to enable.
+  # antigravity-interactions:
+  #   agent: "projects/vertex-agent-fishfood/locations/global/agents/antigravity-preview-05-2026"
 
 telemetry:
   otlp:

--- a/ax.yaml
+++ b/ax.yaml
@@ -29,7 +29,7 @@ harnesses:
     default: true
   # TODO(wjjclaud): Uncomment when ready to enable.
   # antigravity-interactions:
-  #   agent: "projects/vertex-agent-fishfood/locations/global/agents/antigravity-preview-05-2026"
+  #   agent: "antigravity-preview-05-2026"
 
 telemetry:
   otlp:

--- a/ax.yaml
+++ b/ax.yaml
@@ -27,9 +27,7 @@ eventlog:
 harnesses:
   antigravity:
     default: true
-  # TODO(wjjclaud): Uncomment when ready to enable.
-  # antigravity-interactions:
-  #   agent: "antigravity-preview-05-2026"
+  antigravity-interactions: {}
 
 telemetry:
   otlp:

--- a/cmd/ax/harness.go
+++ b/cmd/ax/harness.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -122,7 +121,7 @@ func runAntigravityInteractionsHarness(ctx context.Context, systemInstructions s
 	if err := setHarnessWorkDir(); err != nil {
 		return err
 	}
-	stateDir, err := harnessStateDir()
+	stateDir, err := antigravityinteractions.DefaultStateDir()
 	if err != nil {
 		return err
 	}
@@ -131,19 +130,6 @@ func runAntigravityInteractionsHarness(ctx context.Context, systemInstructions s
 		StateDir:          stateDir,
 	}
 	return antigravityinteractions.Serve(ctx, cfg, harnessHost, harnessPort, harnessReadyzPort)
-}
-
-// harnessStateDir returns the directory for persisting resume cursors: a
-// dedicated "~/.ax/cursors" under the user's home directory. It lives OUTSIDE the
-// agent's working directory on purpose -- the working directory is the agent's
-// operating surface (it reads and edits files there, including hidden ones), so
-// AX's internal state is kept separate to avoid the agent seeing or clobbering it.
-func harnessStateDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolving home directory for resume-cursor state: %w", err)
-	}
-	return filepath.Join(home, ".ax", "cursors"), nil
 }
 
 // serveReadyz serves the HTTP /readyz endpoint on readyzPort that substrate's

--- a/cmd/ax/internal/cliutil/cliutil.go
+++ b/cmd/ax/internal/cliutil/cliutil.go
@@ -24,10 +24,9 @@ import (
 	"github.com/google/ax/internal/controller/eventlog"
 	"github.com/google/ax/internal/harness"
 	"github.com/google/ax/internal/harness/antigravity"
+	"github.com/google/ax/internal/harness/antigravityinteractions"
 	"github.com/google/ax/internal/harness/substrate"
 )
-
-const antigravityHarnessID = "antigravity"
 
 // Controller is the active controller type for this build.
 type Controller = *controller.Controller
@@ -56,10 +55,11 @@ func NewControllerFromConfig(ctx context.Context, cfg *Config) (*controller.Cont
 	// substrate actors ("1").
 	substrateMode := os.Getenv("AX_SUBSTRATE") == "1"
 
-	// Built-in harnesses.
 	var defaultHarnessID string
-	var antigravityHarness harness.Harness
 	var err error
+
+	// Built-in Antigravity harness.
+	var antigravityHarness harness.Harness
 	if !substrateMode {
 		address := cfg.Harnesses.Antigravity.Endpoint
 		if address == "" {
@@ -67,16 +67,46 @@ func NewControllerFromConfig(ctx context.Context, cfg *Config) (*controller.Cont
 		}
 		antigravityHarness = antigravity.New(address)
 	} else {
-		antigravityHarness, err = substrate.New(antigravityHarnessID, "", "", "", 80)
+		antigravityHarness, err = substrate.New(config.AntigravityHarnessID, "", "", "", 80)
 		if err != nil {
 			return nil, fmt.Errorf("antigravity harness: %w", err)
 		}
 	}
-	if err := reg.RegisterHarness(antigravityHarnessID, antigravityHarness); err != nil {
+	if err := reg.RegisterHarness(config.AntigravityHarnessID, antigravityHarness); err != nil {
 		return nil, fmt.Errorf("register antigravity harness: %w", err)
 	}
 	if cfg.Harnesses.Antigravity.Default {
-		defaultHarnessID = antigravityHarnessID
+		defaultHarnessID = config.AntigravityHarnessID
+	}
+
+	// Built-in Antigravity Interactions harness.
+	if ic := cfg.Harnesses.AntigravityInteractions; ic.Agent != "" {
+		var antigravityInteractionsHarness harness.Harness
+		if !substrateMode {
+			stateDir := ic.StateDir
+			if stateDir == "" {
+				stateDir, err = antigravityinteractions.DefaultStateDir()
+				if err != nil {
+					return nil, fmt.Errorf("antigravity-interactions harness: %w", err)
+				}
+			}
+			antigravityInteractionsHarness, err = antigravityinteractions.New(antigravityinteractions.AntigravityInteractionsConfig{
+				Agent:             ic.Agent,
+				SystemInstruction: ic.SystemInstruction,
+				StateDir:          stateDir,
+			})
+		} else {
+			antigravityInteractionsHarness, err = substrate.New(config.AntigravityInteractionsHarnessID, "", "", "", 80)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("antigravity-interactions harness: %w", err)
+		}
+		if err := reg.RegisterHarness(config.AntigravityInteractionsHarnessID, antigravityInteractionsHarness); err != nil {
+			return nil, fmt.Errorf("register antigravity-interactions harness: %w", err)
+		}
+		if ic.Default {
+			defaultHarnessID = config.AntigravityInteractionsHarnessID
+		}
 	}
 
 	// Custom substrate harnesses.

--- a/cmd/ax/internal/cliutil/cliutil.go
+++ b/cmd/ax/internal/cliutil/cliutil.go
@@ -90,33 +90,34 @@ func NewControllerFromConfig(ctx context.Context, cfg *Config) (*controller.Cont
 	}
 
 	// Built-in Antigravity Interactions harness.
-	if ic := cfg.Harnesses.AntigravityInteractions; ic.Agent != "" {
-		var antigravityInteractionsHarness harness.Harness
-		if !substrateMode {
-			stateDir := ic.StateDir
-			if stateDir == "" {
-				stateDir, err = antigravityinteractions.DefaultStateDir()
-				if err != nil {
-					return nil, fmt.Errorf("antigravity-interactions harness: %w", err)
-				}
+	var antigravityInteractionsHarness harness.Harness
+	if !substrateMode {
+		agent := cfg.Harnesses.AntigravityInteractions.Agent
+		if agent == "" {
+			agent = antigravityinteractions.DefaultAgent
+		}
+		stateDir := cfg.Harnesses.AntigravityInteractions.StateDir
+		if stateDir == "" {
+			stateDir, err = antigravityinteractions.DefaultStateDir()
+			if err != nil {
+				return nil, fmt.Errorf("antigravity-interactions harness: %w", err)
 			}
-			antigravityInteractionsHarness, err = antigravityinteractions.New(antigravityinteractions.AntigravityInteractionsConfig{
-				Agent:             ic.Agent,
-				SystemInstruction: ic.SystemInstruction,
-				StateDir:          stateDir,
-			})
-		} else {
-			antigravityInteractionsHarness, err = substrate.New(config.AntigravityInteractionsHarnessID, "", "", "", 80)
 		}
-		if err != nil {
-			return nil, fmt.Errorf("antigravity-interactions harness: %w", err)
-		}
-		if err := reg.RegisterHarness(config.AntigravityInteractionsHarnessID, antigravityInteractionsHarness); err != nil {
-			return nil, fmt.Errorf("register antigravity-interactions harness: %w", err)
-		}
-		if ic.Default {
-			defaultHarnessID = config.AntigravityInteractionsHarnessID
-		}
+		antigravityInteractionsHarness, err = antigravityinteractions.New(antigravityinteractions.AntigravityInteractionsConfig{
+			Agent:    agent,
+			StateDir: stateDir,
+		})
+	} else {
+		antigravityInteractionsHarness, err = substrate.New(config.AntigravityInteractionsHarnessID, "", "", "", 80)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("antigravity-interactions harness: %w", err)
+	}
+	if err := reg.RegisterHarness(config.AntigravityInteractionsHarnessID, antigravityInteractionsHarness); err != nil {
+		return nil, fmt.Errorf("register antigravity-interactions harness: %w", err)
+	}
+	if cfg.Harnesses.AntigravityInteractions.Default {
+		defaultHarnessID = config.AntigravityInteractionsHarnessID
 	}
 
 	for _, sc := range cfg.Harnesses.Substrate {

--- a/cmd/ax/internal/cliutil/cliutil_test.go
+++ b/cmd/ax/internal/cliutil/cliutil_test.go
@@ -49,40 +49,6 @@ func TestNewControllerFromConfig_BuiltinSubstrate(t *testing.T) {
 	c.Close()
 }
 
-func TestNewControllerFromConfig_InteractionsLocalDefaultsStateDir(t *testing.T) {
-	t.Setenv("AX_SUBSTRATE", "")  // local mode: the harness is built in-process
-	t.Setenv("HOME", t.TempDir()) // DefaultStateDir() resolves under a temp home
-
-	cfg := &config.Config{
-		EventLog: config.EventLogConfig{
-			SQLiteConfig: config.SQLiteConfig{
-				Filename: filepath.Join(t.TempDir(), "log.sqlite"),
-			},
-		},
-		Harnesses: config.HarnessesConfig{
-			Antigravity: config.AntigravityHarnessConfig{Default: true},
-			AntigravityInteractions: config.AntigravityInteractionsHarnessConfig{
-				Agent: "projects/p/locations/global/agents/a",
-				// StateDir omitted -> cliutil applies the ~/.ax/cursors default.
-			},
-		},
-	}
-
-	c, err := NewControllerFromConfig(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("NewControllerFromConfig: %v", err)
-	}
-	if c == nil {
-		t.Fatal("expected non-nil controller")
-	}
-	defer c.Close()
-
-	// With a default state dir applied, the harness still registers locally.
-	if _, err := c.Registry().Harness(config.AntigravityInteractionsHarnessID); err != nil {
-		t.Errorf("interactions harness not registered with a defaulted state_dir: %v", err)
-	}
-}
-
 func TestNewControllerFromConfig_InteractionsSubstrate(t *testing.T) {
 	t.Setenv("AX_SUBSTRATE", "1")
 

--- a/cmd/ax/internal/cliutil/cliutil_test.go
+++ b/cmd/ax/internal/cliutil/cliutil_test.go
@@ -60,9 +60,6 @@ func TestNewControllerFromConfig_InteractionsSubstrate(t *testing.T) {
 		},
 		Harnesses: config.HarnessesConfig{
 			Antigravity: config.AntigravityHarnessConfig{Default: true},
-			AntigravityInteractions: config.AntigravityInteractionsHarnessConfig{
-				Agent: "projects/p/locations/global/agents/a",
-			},
 		},
 	}
 
@@ -75,7 +72,6 @@ func TestNewControllerFromConfig_InteractionsSubstrate(t *testing.T) {
 	}
 	defer c.Close()
 
-	// In substrate mode the agent still gates registration (state_dir unneeded).
 	if _, err := c.Registry().Harness(config.AntigravityInteractionsHarnessID); err != nil {
 		t.Errorf("interactions harness not registered in substrate mode: %v", err)
 	}

--- a/cmd/ax/internal/cliutil/cliutil_test.go
+++ b/cmd/ax/internal/cliutil/cliutil_test.go
@@ -74,6 +74,72 @@ func TestNewControllerFromConfig_BuiltinSubstrate(t *testing.T) {
 	c.Close()
 }
 
+func TestNewControllerFromConfig_InteractionsLocalDefaultsStateDir(t *testing.T) {
+	t.Setenv("AX_SUBSTRATE", "")  // local mode: the harness is built in-process
+	t.Setenv("HOME", t.TempDir()) // DefaultStateDir() resolves under a temp home
+
+	cfg := &config.Config{
+		EventLog: config.EventLogConfig{
+			SQLiteConfig: config.SQLiteConfig{
+				Filename: filepath.Join(t.TempDir(), "log.sqlite"),
+			},
+		},
+		Harnesses: config.HarnessesConfig{
+			Antigravity: config.AntigravityHarnessConfig{Default: true},
+			AntigravityInteractions: config.AntigravityInteractionsHarnessConfig{
+				Agent: "projects/p/locations/global/agents/a",
+				// StateDir omitted -> cliutil applies the ~/.ax/cursors default.
+			},
+		},
+	}
+
+	c, err := NewControllerFromConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewControllerFromConfig: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil controller")
+	}
+	defer c.Close()
+
+	// With a default state dir applied, the harness still registers locally.
+	if _, err := c.Registry().Harness(config.AntigravityInteractionsHarnessID); err != nil {
+		t.Errorf("interactions harness not registered with a defaulted state_dir: %v", err)
+	}
+}
+
+func TestNewControllerFromConfig_InteractionsSubstrate(t *testing.T) {
+	t.Setenv("AX_SUBSTRATE", "1")
+
+	cfg := &config.Config{
+		EventLog: config.EventLogConfig{
+			SQLiteConfig: config.SQLiteConfig{
+				Filename: filepath.Join(t.TempDir(), "log.sqlite"),
+			},
+		},
+		Harnesses: config.HarnessesConfig{
+			Antigravity: config.AntigravityHarnessConfig{Default: true},
+			AntigravityInteractions: config.AntigravityInteractionsHarnessConfig{
+				Agent: "projects/p/locations/global/agents/a",
+			},
+		},
+	}
+
+	c, err := NewControllerFromConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewControllerFromConfig: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil controller")
+	}
+	defer c.Close()
+
+	// In substrate mode the agent still gates registration (state_dir unneeded).
+	if _, err := c.Registry().Harness(config.AntigravityInteractionsHarnessID); err != nil {
+		t.Errorf("interactions harness not registered in substrate mode: %v", err)
+	}
+}
+
 func TestNewControllerFromConfig_CustomHarnessRequiresSubstrateMode(t *testing.T) {
 	t.Setenv("AX_SUBSTRATE", "")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,10 +96,9 @@ type AntigravityHarnessConfig struct {
 // AntigravityInteractionsHarnessConfig registers the built-in Antigravity
 // Interactions harness (over the Vertex GenAI Interactions API).
 type AntigravityInteractionsHarnessConfig struct {
-	Default           bool   `yaml:"default,omitempty"`            // Default harness or not
-	Agent             string `yaml:"agent"`                        // Interactions API agent
-	SystemInstruction string `yaml:"system_instruction,omitempty"` // Optional system prompt
-	StateDir          string `yaml:"state_dir,omitempty"`          // Resume-cursor directory (optional; defaults to ~/.ax/cursors)
+	Default  bool   `yaml:"default,omitempty"`   // Default harness or not
+	Agent    string `yaml:"agent,omitempty"`     // Interactions API agent (default: antigravityinteractions.DefaultAgent)
+	StateDir string `yaml:"state_dir,omitempty"` // Resume-cursor directory (optional; defaults to ~/.ax/antigravityinteractions/cursors)
 }
 
 // SubstrateHarnessConfig registers a custom harness deployed on substrate

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,9 @@ const (
 	// The port for harnesses running as substrate actors. Substrate's
 	// actor networking DNATs inbound workerPodIP:80 to the actor.
 	substrateDefaultPort = 80
+	// Harness IDs reserved for AX's built-in harnesses.
+	AntigravityHarnessID             = "antigravity"
+	AntigravityInteractionsHarnessID = "antigravity-interactions"
 )
 
 // Config represents the main configuration for the AX harness server.
@@ -74,19 +77,29 @@ type EventLogConfig struct {
 }
 
 // HarnessesConfig groups harnesses to serve by type. There are two categories:
-//   - Built-in harnesses (e.g. Antigravity) whose implementation and container
-//     image are provided by AX.
+//   - Built-in harnesses (e.g. Antigravity, AntigravityInteractions) whose
+//     implementation and container image are provided by AX.
 //   - Custom harnesses on substrate whose implementation and container image are
 //     provided by the user via their own ActorTemplate.
 type HarnessesConfig struct {
-	Antigravity AntigravityHarnessConfig `yaml:"antigravity,omitempty"`
-	Substrate   []SubstrateHarnessConfig `yaml:"substrate,omitempty"`
+	Antigravity             AntigravityHarnessConfig             `yaml:"antigravity,omitempty"`
+	AntigravityInteractions AntigravityInteractionsHarnessConfig `yaml:"antigravity-interactions,omitempty"`
+	Substrate               []SubstrateHarnessConfig             `yaml:"substrate,omitempty"`
 }
 
 // AntigravityHarnessConfig registers the built-in Antigravity harness.
 type AntigravityHarnessConfig struct {
 	Default  bool   `yaml:"default,omitempty"`
 	Endpoint string `yaml:"endpoint,omitempty"` // HarnessService address
+}
+
+// AntigravityInteractionsHarnessConfig registers the built-in Antigravity
+// Interactions harness (over the Vertex GenAI Interactions API).
+type AntigravityInteractionsHarnessConfig struct {
+	Default           bool   `yaml:"default,omitempty"`            // Default harness or not
+	Agent             string `yaml:"agent"`                        // Interactions API agent
+	SystemInstruction string `yaml:"system_instruction,omitempty"` // Optional system prompt
+	StateDir          string `yaml:"state_dir,omitempty"`          // Resume-cursor directory (optional; defaults to ~/.ax/cursors)
 }
 
 // SubstrateHarnessConfig registers a custom harness deployed on substrate
@@ -165,13 +178,16 @@ func (c *Config) Validate() error {
 	if c.Harnesses.Antigravity.Default {
 		defaultCount++
 	}
+	if c.Harnesses.AntigravityInteractions.Default {
+		defaultCount++
+	}
 
 	for _, sc := range c.Harnesses.Substrate {
 		if sc.ID == "" {
 			return fmt.Errorf("substrate harness id is required")
 		}
-		if sc.ID == "antigravity" {
-			return fmt.Errorf("substrate harness id %q is reserved for the built-in antigravity harness", sc.ID)
+		if sc.ID == AntigravityHarnessID || sc.ID == AntigravityInteractionsHarnessID {
+			return fmt.Errorf("substrate harness id %q is reserved for built-in harnesses", sc.ID)
 		}
 		if sc.Namespace == "" {
 			return fmt.Errorf("substrate harness %q: namespace is required", sc.ID)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -103,6 +103,26 @@ func TestValidate_MultipleDefaults(t *testing.T) {
 	}
 }
 
+func TestValidate_InteractionsIDReserved(t *testing.T) {
+	c := validConfig()
+	c.Harnesses.Substrate[0].ID = "antigravity-interactions"
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("Validate() = %v, want reserved id error", err)
+	}
+}
+
+func TestValidate_InteractionsValid(t *testing.T) {
+	c := validConfig()
+	c.Harnesses.AntigravityInteractions = AntigravityInteractionsHarnessConfig{
+		Agent:    "projects/p/locations/global/agents/a",
+		StateDir: "interactions-state",
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}
+
 func TestLoadFromFile_Version(t *testing.T) {
 	data := `
 version: "1.2.3"

--- a/internal/harness/antigravityinteractions/antigravityinteractions.go
+++ b/internal/harness/antigravityinteractions/antigravityinteractions.go
@@ -66,27 +66,29 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-// cloudPlatformScope is the OAuth2 scope required to call Vertex AI.
-const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+const (
+	// interactionsEndpoint is the public Vertex GenAI dataplane endpoint.
+	interactionsEndpoint = "https://aiplatform.googleapis.com"
+	// interactionsAPIVersion is the Interactions API version this harness targets.
+	interactionsAPIVersion = "v1beta1"
+	// cloudPlatformScope is the OAuth2 scope required to call Vertex AI.
+	cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+	// Cloud project and location are read from these standard environment
+	// variables (see https://github.com/google/ax#authentication).
+	envCloudProject  = "GOOGLE_CLOUD_PROJECT"
+	envCloudLocation = "GOOGLE_CLOUD_LOCATION"
+	// defaultLocation is used when GOOGLE_CLOUD_LOCATION is unset.
+	defaultLocation = "global"
+
+	// DefaultAgent is the Interactions API agent used when the harness is
+	// registered without an explicit agent override.
+	DefaultAgent = "antigravity-preview-05-2026"
+)
 
 // Compile-time interface assertions.
 var _ harness.Harness = (*AntigravityInteractionsHarness)(nil)
 var _ harness.Execution = (*antigravityInteractionsExecution)(nil)
-
-const interactionsAPIVersion = "v1beta1"
-
-// interactionsEndpoint is the public Vertex GenAI dataplane endpoint.
-const interactionsEndpoint = "https://aiplatform.googleapis.com"
-
-// Cloud project and location are read from these standard environment variables
-// (see https://github.com/google/ax#authentication).
-const (
-	envCloudProject  = "GOOGLE_CLOUD_PROJECT"
-	envCloudLocation = "GOOGLE_CLOUD_LOCATION"
-)
-
-// defaultLocation is used when GOOGLE_CLOUD_LOCATION is unset.
-const defaultLocation = "global"
 
 // AntigravityInteractionsConfig configures an AntigravityInteractionsHarness.
 // Use New, which fills sensible defaults.
@@ -155,7 +157,7 @@ func cloudLocation() string {
 	return defaultLocation
 }
 
-// DefaultStateDir returns the default resume-cursor directory, ~/.ax/cursors,
+// DefaultStateDir returns the default resume-cursor directory, ~/.ax/antigravityinteractions/cursors,
 // used when a caller does not set StateDir explicitly. It lives outside the
 // agent's working directory on purpose: the working directory is the agent's
 // operating surface (it reads and edits files there), so AX's internal state is
@@ -166,7 +168,7 @@ func DefaultStateDir() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolving home directory for resume-cursor state: %w", err)
 	}
-	return filepath.Join(home, ".ax", "cursors"), nil
+	return filepath.Join(home, ".ax", "antigravityinteractions", "cursors"), nil
 }
 
 // AntigravityInteractionsHarness implements Harness by talking to the public

--- a/internal/harness/antigravityinteractions/antigravityinteractions.go
+++ b/internal/harness/antigravityinteractions/antigravityinteractions.go
@@ -52,6 +52,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -152,6 +153,20 @@ func cloudLocation() string {
 		return loc
 	}
 	return defaultLocation
+}
+
+// DefaultStateDir returns the default resume-cursor directory, ~/.ax/cursors,
+// used when a caller does not set StateDir explicitly. It lives outside the
+// agent's working directory on purpose: the working directory is the agent's
+// operating surface (it reads and edits files there), so AX's internal state is
+// kept separate to avoid the agent seeing or clobbering it. New still requires a
+// non-empty StateDir; callers apply this default.
+func DefaultStateDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory for resume-cursor state: %w", err)
+	}
+	return filepath.Join(home, ".ax", "cursors"), nil
 }
 
 // AntigravityInteractionsHarness implements Harness by talking to the public

--- a/internal/harness/antigravityinteractions/antigravityinteractions_test.go
+++ b/internal/harness/antigravityinteractions/antigravityinteractions_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -219,5 +220,19 @@ func TestCursorStoreLoadSave(t *testing.T) {
 	}
 	if cur.PrevInteractionID != "INT-8" {
 		t.Errorf("after overwrite PrevInteractionID = %q, want %q", cur.PrevInteractionID, "INT-8")
+	}
+}
+
+// TestDefaultStateDir returns ~/.ax/cursors under the user's home directory.
+func TestDefaultStateDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := DefaultStateDir()
+	if err != nil {
+		t.Fatalf("DefaultStateDir: %v", err)
+	}
+	if want := filepath.Join(home, ".ax", "cursors"); got != want {
+		t.Errorf("DefaultStateDir() = %q, want %q", got, want)
 	}
 }

--- a/internal/harness/antigravityinteractions/antigravityinteractions_test.go
+++ b/internal/harness/antigravityinteractions/antigravityinteractions_test.go
@@ -223,7 +223,8 @@ func TestCursorStoreLoadSave(t *testing.T) {
 	}
 }
 
-// TestDefaultStateDir returns ~/.ax/cursors under the user's home directory.
+// TestDefaultStateDir returns ~/.ax/antigravityinteractions/cursors under the
+// user's home directory.
 func TestDefaultStateDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -232,7 +233,7 @@ func TestDefaultStateDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultStateDir: %v", err)
 	}
-	if want := filepath.Join(home, ".ax", "cursors"); got != want {
+	if want := filepath.Join(home, ".ax", "antigravityinteractions", "cursors"); got != want {
 		t.Errorf("DefaultStateDir() = %q, want %q", got, want)
 	}
 }

--- a/manifests/ax-deployment.yaml
+++ b/manifests/ax-deployment.yaml
@@ -133,3 +133,6 @@ data:
     harnesses:
       antigravity:
         default: true
+      # TODO(wjjclaud): Uncomment when ready to enable.
+      # antigravity-interactions:
+      #   agent: "projects/vertex-agent-fishfood/locations/global/agents/antigravity-preview-05-2026"

--- a/manifests/ax-deployment.yaml
+++ b/manifests/ax-deployment.yaml
@@ -133,6 +133,4 @@ data:
     harnesses:
       antigravity:
         default: true
-      # TODO(wjjclaud): Uncomment when ready to enable.
-      # antigravity-interactions:
-      #   agent: "antigravity-preview-05-2026"
+      antigravity-interactions: {}

--- a/manifests/ax-deployment.yaml
+++ b/manifests/ax-deployment.yaml
@@ -135,4 +135,4 @@ data:
         default: true
       # TODO(wjjclaud): Uncomment when ready to enable.
       # antigravity-interactions:
-      #   agent: "projects/vertex-agent-fishfood/locations/global/agents/antigravity-preview-05-2026"
+      #   agent: "antigravity-preview-05-2026"


### PR DESCRIPTION
Wires the built-in Antigravity Interactions harness into the controller for #271.
- Config (internal/config): new antigravity interactions harness config.
- Registry wiring (cmd/ax/internal/cliutil): registers for both local mode and substrate mode.
- Default state dir: move the default state dir helper to the shared package.
- Example yaml commented out for enabling in followups.

### Tested
On local mode, uncomment config in `ax.yaml`
`export GOOGLE_CLOUD_PROJECT=<project_ID>`
`go run ./cmd/ax exec --harness antigravity-interactions --input "hello"`

### Follow up
Routing in `ax harness` for substrate mode.