### PR TITLE
Setup ~/.ax/antigravity once until a new update arrives

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/google/ax/internal/harness"
 	"github.com/google/ax/internal/harness/substrate"
@@ -207,4 +208,12 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func AXAssetsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ".ax"), nil
 }

--- a/internal/harness/antigravityinteractions/antigravityinteractions.go
+++ b/internal/harness/antigravityinteractions/antigravityinteractions.go
@@ -59,6 +59,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/ax/internal/config"
 	"github.com/google/ax/internal/harness"
 	"github.com/google/ax/proto"
 	"github.com/google/uuid"
@@ -164,11 +165,11 @@ func cloudLocation() string {
 // kept separate to avoid the agent seeing or clobbering it. New still requires a
 // non-empty StateDir; callers apply this default.
 func DefaultStateDir() (string, error) {
-	home, err := os.UserHomeDir()
+	axDir, err := config.AXAssetsDir()
 	if err != nil {
-		return "", fmt.Errorf("resolving home directory for resume-cursor state: %w", err)
+		return "", err
 	}
-	return filepath.Join(home, ".ax", "antigravityinteractions", "cursors"), nil
+	return filepath.Join(axDir, "antigravityinteractions", "cursors"), nil
 }
 
 // AntigravityInteractionsHarness implements Harness by talking to the public

--- a/internal/pythonsidecar/setup.go
+++ b/internal/pythonsidecar/setup.go
@@ -15,7 +15,6 @@
 package pythonsidecar
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -23,7 +22,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 
 	"github.com/google/ax/internal/config"
 )
@@ -48,18 +46,21 @@ func Setup(ctx context.Context, opts SetupOptions) (string, error) {
 	reqPath := filepath.Join(extractDir, "antigravity", "requirements.txt")
 
 	pythonPath := axDir + string(os.PathListSeparator) + extractDir
-	if err := extractFS(ctx, opts.FS, extractDir); err != nil {
+	updated, err := extractFS(ctx, opts.FS, extractDir)
+	if err != nil {
 		return "", fmt.Errorf("failed to extract embedded assets: %w", err)
 	}
-	pkgPath, err := install(ctx, reqPath)
+
+	pkgPath, err := install(ctx, reqPath, updated)
 	if err != nil {
 		return "", err
 	}
 	return pythonPath + string(os.PathListSeparator) + pkgPath, nil
 }
 
-func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
-	return fs.WalkDir(filesystem, ".", func(path string, d fs.DirEntry, err error) error {
+func extractFS(ctx context.Context, filesystem fs.FS, destDir string) (bool, error) {
+	var updated bool
+	err := fs.WalkDir(filesystem, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -67,8 +68,9 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
 			return ctx.Err()
 		}
 
+		destPath := filepath.Join(destDir, filepath.FromSlash(path))
 		if d.IsDir() {
-			return nil
+			return os.MkdirAll(destPath, 0755)
 		}
 
 		info, err := d.Info()
@@ -76,20 +78,12 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
 			return err
 		}
 
-		destPath := filepath.Join(destDir, filepath.FromSlash(path))
-		// If the file already exists on disk with the exact same size and content,
+		stat, err := os.Stat(destPath)
+		// If the file already exists on disk with the exact same size,
 		// skip copying to preserve its timestamp and avoid false re-installations.
-		if stat, err := os.Stat(destPath); err == nil && stat.Size() == info.Size() {
-			src, err := filesystem.Open(path)
-			if err != nil {
-				return fmt.Errorf("opening embedded file %s: %w", path, err)
-			}
-			embedded, err := io.ReadAll(src)
-			_ = src.Close()
-			if err == nil {
-				if existing, err := os.ReadFile(destPath); err == nil && bytes.Equal(existing, embedded) {
-					return nil
-				}
+		if err == nil {
+			if stat.Size() == info.Size() {
+				return nil
 			}
 		}
 
@@ -97,6 +91,8 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
 			return fmt.Errorf("creating directory for %s: %w", destPath, err)
 		}
 
+		// There is at least, one file updated.
+		updated = true
 		src, err := filesystem.Open(path)
 		if err != nil {
 			return fmt.Errorf("opening embedded file %s: %w", path, err)
@@ -107,9 +103,7 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
 		if info.Mode().Perm() != 0 {
 			mode = info.Mode().Perm() | 0200
 		}
-
 		_ = os.Chmod(destPath, 0644)
-
 		dst, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 		if err != nil {
 			return fmt.Errorf("creating destination file %s: %w", destPath, err)
@@ -119,36 +113,25 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
 			_ = dst.Close()
 			return fmt.Errorf("writing file %s: %w", destPath, err)
 		}
-
 		if err := dst.Close(); err != nil {
 			return fmt.Errorf("closing file %s: %w", destPath, err)
 		}
-
 		return nil
 	})
+	return updated, err
 }
 
-func install(ctx context.Context, reqPath string) (string, error) {
+func install(ctx context.Context, reqPath string, install bool) (string, error) {
 	pkgDir := filepath.Join(filepath.Dir(reqPath), "site-packages")
-	reqStat, err := os.Stat(reqPath)
-	if err != nil {
-		return "", fmt.Errorf("stat requirements file %s: %w", reqPath, err)
+	if !install {
+		if _, err := os.Stat(pkgDir); err == nil {
+			return pkgDir, nil
+		}
 	}
-
-	// Skip pip install if site-packages/ already exists and is newer than or equal to requirements.txt.
-	// This avoids spawning Python or making network requests on every command execution when dependencies are up to date.
-	if pkgStat, err := os.Stat(pkgDir); err == nil && !reqStat.ModTime().After(pkgStat.ModTime()) {
-		return pkgDir, nil
-	}
-
 	cmd := exec.CommandContext(ctx, "python3", "-m", "pip", "install", "--extra-index-url", "https://pypi.org/simple", "--target", pkgDir, "-r", reqPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("pip install failed for %s: %w\nOutput:\n%s", reqPath, err, string(out))
 	}
-	// Touch site-packages/ upon successful installation so its modification time is guaranteed
-	// to be newer than requirements.txt for subsequent runs.
-	now := time.Now()
-	_ = os.Chtimes(pkgDir, now, now)
 	return pkgDir, nil
 }

--- a/internal/pythonsidecar/setup.go
+++ b/internal/pythonsidecar/setup.go
@@ -39,28 +39,22 @@ func Setup(ctx context.Context, opts SetupOptions) (string, error) {
 	if opts.FS == nil {
 		return "", fmt.Errorf("SetupOptions.FS cannot be nil")
 	}
-
 	axDir, err := config.AXAssetsDir()
 	if err != nil {
 		return "", err
 	}
-	targetDir := axDir
-
-	extractDir := filepath.Join(targetDir, "python")
+	extractDir := filepath.Join(axDir, "python")
 	reqPath := filepath.Join(extractDir, "antigravity", "requirements.txt")
 
-	result := targetDir + string(os.PathListSeparator) + extractDir
-
+	pythonPath := axDir + string(os.PathListSeparator) + extractDir
 	if err := extractFS(ctx, opts.FS, extractDir); err != nil {
 		return "", fmt.Errorf("failed to extract embedded assets: %w", err)
 	}
-
 	pkgPath, err := install(ctx, reqPath)
 	if err != nil {
 		return "", err
 	}
-
-	return result + string(os.PathListSeparator) + pkgPath, nil
+	return pythonPath + string(os.PathListSeparator) + pkgPath, nil
 }
 
 func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {

--- a/internal/pythonsidecar/setup.go
+++ b/internal/pythonsidecar/setup.go
@@ -131,9 +131,6 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
 func install(ctx context.Context, reqPath string) (string, error) {
 	pkgDir := filepath.Join(filepath.Dir(reqPath), "site-packages")
 	reqStat, err := os.Stat(reqPath)
-	if os.IsNotExist(err) {
-		return pkgDir, nil
-	}
 	if err != nil {
 		return "", fmt.Errorf("stat requirements file %s: %w", reqPath, err)
 	}

--- a/internal/pythonsidecar/setup.go
+++ b/internal/pythonsidecar/setup.go
@@ -23,15 +23,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/ax/internal/config"
 )
 
 // SetupOptions configures asset extraction and environment setup for a Python sidecar.
 type SetupOptions struct {
 	// FS is the embedded filesystem containing Python assets (e.g., python.FS). (Required)
 	FS fs.FS
-	// TargetDir is the directory on disk where assets will be extracted.
-	// If empty, it defaults to filepath.Join(os.UserHomeDir(), ".ax"). (Optional)
-	TargetDir string
 }
 
 // Setup extracts the embedded filesystem assets to TargetDir.
@@ -41,14 +40,11 @@ func Setup(ctx context.Context, opts SetupOptions) (string, error) {
 		return "", fmt.Errorf("SetupOptions.FS cannot be nil")
 	}
 
-	targetDir := opts.TargetDir
-	if targetDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("resolving home directory for python target dir: %w", err)
-		}
-		targetDir = filepath.Join(home, ".ax")
+	axDir, err := config.AXAssetsDir()
+	if err != nil {
+		return "", err
 	}
+	targetDir := axDir
 
 	extractDir := filepath.Join(targetDir, "python")
 	reqPath := filepath.Join(extractDir, "antigravity", "requirements.txt")

--- a/internal/pythonsidecar/setup.go
+++ b/internal/pythonsidecar/setup.go
@@ -15,6 +15,7 @@
 package pythonsidecar
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -22,7 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
+	"time"
 
 	"github.com/google/ax/internal/config"
 )
@@ -70,10 +71,26 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
 			return nil
 		}
 
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
 		destPath := filepath.Join(destDir, filepath.FromSlash(path))
-		rel, err := filepath.Rel(destDir, destPath)
-		if err != nil || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
-			return fmt.Errorf("illegal file path in embedded FS: %s", path)
+		// If the file already exists on disk with the exact same size and content,
+		// skip copying to preserve its timestamp and avoid false re-installations.
+		if stat, err := os.Stat(destPath); err == nil && stat.Size() == info.Size() {
+			src, err := filesystem.Open(path)
+			if err != nil {
+				return fmt.Errorf("opening embedded file %s: %w", path, err)
+			}
+			embedded, err := io.ReadAll(src)
+			_ = src.Close()
+			if err == nil {
+				if existing, err := os.ReadFile(destPath); err == nil && bytes.Equal(existing, embedded) {
+					return nil
+				}
+			}
 		}
 
 		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
@@ -86,9 +103,8 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
 		}
 		defer src.Close()
 
-		info, err := d.Info()
 		mode := os.FileMode(0644)
-		if err == nil && info.Mode().Perm() != 0 {
+		if info.Mode().Perm() != 0 {
 			mode = info.Mode().Perm() | 0200
 		}
 
@@ -114,10 +130,28 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) error {
 
 func install(ctx context.Context, reqPath string) (string, error) {
 	pkgDir := filepath.Join(filepath.Dir(reqPath), "site-packages")
+	reqStat, err := os.Stat(reqPath)
+	if os.IsNotExist(err) {
+		return pkgDir, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("stat requirements file %s: %w", reqPath, err)
+	}
+
+	// Skip pip install if site-packages/ already exists and is newer than or equal to requirements.txt.
+	// This avoids spawning Python or making network requests on every command execution when dependencies are up to date.
+	if pkgStat, err := os.Stat(pkgDir); err == nil && !reqStat.ModTime().After(pkgStat.ModTime()) {
+		return pkgDir, nil
+	}
+
 	cmd := exec.CommandContext(ctx, "python3", "-m", "pip", "install", "--extra-index-url", "https://pypi.org/simple", "--target", pkgDir, "-r", reqPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("pip install failed for %s: %w\nOutput:\n%s", reqPath, err, string(out))
 	}
+	// Touch site-packages/ upon successful installation so its modification time is guaranteed
+	// to be newer than requirements.txt for subsequent runs.
+	now := time.Now()
+	_ = os.Chtimes(pkgDir, now, now)
 	return pkgDir, nil
 }

--- a/internal/pythonsidecar/setup.go
+++ b/internal/pythonsidecar/setup.go
@@ -131,6 +131,9 @@ func install(ctx context.Context, reqPath string, install bool) (string, error) 
 		}
 	}
 	fmt.Println("Setting up Antigravity SDK, this may take a while...")
+
+	// Some corp machines are overriding the indexes, ensure that
+	// simple index is included where Antigravity SDK is distributed from.
 	cmd := exec.CommandContext(ctx, "python3", "-m", "pip", "install", "--extra-index-url", "https://pypi.org/simple", "--target", pkgDir, "-r", reqPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/pythonsidecar/setup.go
+++ b/internal/pythonsidecar/setup.go
@@ -128,6 +128,7 @@ func install(ctx context.Context, reqPath string, install bool) (string, error) 
 			return pkgDir, nil
 		}
 	}
+	fmt.Println("Setting up Antigravity SDK, this may take a while...")
 	cmd := exec.CommandContext(ctx, "python3", "-m", "pip", "install", "--extra-index-url", "https://pypi.org/simple", "--target", pkgDir, "-r", reqPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/pythonsidecar/setup.go
+++ b/internal/pythonsidecar/setup.go
@@ -124,6 +124,8 @@ func extractFS(ctx context.Context, filesystem fs.FS, destDir string) (bool, err
 func install(ctx context.Context, reqPath string, install bool) (string, error) {
 	pkgDir := filepath.Join(filepath.Dir(reqPath), "site-packages")
 	if !install {
+		// Make sure that pip install ran once and we have
+		// the dependencies installed under site-packages.
 		if _, err := os.Stat(pkgDir); err == nil {
 			return pkgDir, nil
 		}

--- a/internal/pythonsidecar/setup_test.go
+++ b/internal/pythonsidecar/setup_test.go
@@ -42,8 +42,7 @@ func TestSetup_EmbeddedFS(t *testing.T) {
 
 	targetDir := filepath.Join(t.TempDir(), "target")
 	opts := pythonsidecar.SetupOptions{
-		FS:        testFS,
-		TargetDir: targetDir,
+		FS: testFS,
 	}
 
 	gotDir, err := pythonsidecar.Setup(context.Background(), opts)

--- a/internal/pythonsidecar/setup_test.go
+++ b/internal/pythonsidecar/setup_test.go
@@ -40,28 +40,27 @@ func TestSetup_EmbeddedFS(t *testing.T) {
 		"proto/ax_pb2.py":               &fstest.MapFile{Data: []byte("print('proto')")},
 	}
 
-	targetDir := filepath.Join(t.TempDir(), "target")
+	targetDir := filepath.Join(t.TempDir(), "home")
+	axDir := filepath.Join(targetDir, ".ax")
+	t.Setenv("HOME", targetDir)
+
 	opts := pythonsidecar.SetupOptions{
 		FS: testFS,
 	}
-
 	gotDir, err := pythonsidecar.Setup(context.Background(), opts)
 	if err != nil {
 		t.Fatalf("Setup() failed: %v", err)
-	}
-	if !strings.HasPrefix(gotDir, targetDir) {
-		t.Errorf("expected gotDir to start with targetDir=%q, got %q", targetDir, gotDir)
 	}
 	if !strings.Contains(gotDir, "python") {
 		t.Errorf("expected gotDir to contain extracted python directory in PYTHONPATH, got %q", gotDir)
 	}
 
 	// Verify files were extracted under TargetDir/python
-	harnessPath := filepath.Join(targetDir, "python", "antigravity", "harness_server.py")
+	harnessPath := filepath.Join(axDir, "python", "antigravity", "harness_server.py")
 	if _, err := os.Stat(harnessPath); err != nil {
 		t.Errorf("expected file %s to exist, got stat error: %v", harnessPath, err)
 	}
-	protoPath := filepath.Join(targetDir, "python", "proto", "ax_pb2.py")
+	protoPath := filepath.Join(axDir, "python", "proto", "ax_pb2.py")
 	if _, err := os.Stat(protoPath); err != nil {
 		t.Errorf("expected file %s to exist, got stat error: %v", protoPath, err)
 	}


### PR DESCRIPTION
- Check if any files in the embed.FS has changed. If not, skip pip install.
- Consolidate .ax directory path resolution into a centralized config helper
