### PR TITLE
Surface server error events in Antigravity Interactions harness

### DIFF
--- a/internal/harness/antigravityinteractions/antigravityinteractions.go
+++ b/internal/harness/antigravityinteractions/antigravityinteractions.go
@@ -797,6 +797,30 @@ func (h *AntigravityInteractionsHarness) postTurnOnce(ctx context.Context, token
 	return h.parseStreamedTurn(resp.Body)
 }
 
+// serverErrorMessage extracts a human-readable message from an SSE "error"
+// event. The error payload is an object with a "message" field (and often a
+// "status"/"code"); e.g. {"error":{"message":"...","status":"INVALID_ARGUMENT"}}.
+// Falls back to a generic string when the shape is unexpected so the caller
+// always gets a non-empty error.
+func serverErrorMessage(event map[string]any) string {
+	errObj, ok := event["error"].(map[string]any)
+	if !ok {
+		return "unknown server error"
+	}
+	msg, _ := errObj["message"].(string)
+	status, _ := errObj["status"].(string)
+	switch {
+	case msg != "" && status != "":
+		return fmt.Sprintf("%s (%s)", msg, status)
+	case msg != "":
+		return msg
+	case status != "":
+		return status
+	default:
+		return "unknown server error"
+	}
+}
+
 // parseStreamedTurn parses the event:/data: Server-Sent Events stream for one
 // interaction turn and extracts the tool calls the agent yielded and the model's
 // text output.
@@ -838,6 +862,19 @@ func (h *AntigravityInteractionsHarness) parseStreamedTurn(body io.Reader) (*tur
 			continue
 		}
 		switch event["event_type"] {
+		case "error":
+			// The server reports a turn-level failure (e.g. INVALID_ARGUMENT for a
+			// malformed client tool result) as an SSE "error" event. Surface it as
+			// a real error so the caller aborts the turn instead of treating the
+			// stream as a completed-but-empty turn. Silently dropping it made an
+			// empty directory listing look like a blank "no response, seq=0" turn
+			// AND caused the failing turn's interaction id to be persisted as a
+			// poisoned resume cursor.
+			return nil, fmt.Errorf(
+				"antigravity interactions: server error event: %s",
+				serverErrorMessage(event),
+			)
+
 		case "interaction.created", "interaction.completed", "interaction.status_update":
 			if interaction, ok := event["interaction"].(map[string]any); ok {
 				if id, ok := interaction["id"].(string); ok && id != "" {

--- a/internal/harness/antigravityinteractions/antigravityinteractions_test.go
+++ b/internal/harness/antigravityinteractions/antigravityinteractions_test.go
@@ -236,3 +236,67 @@ func TestDefaultStateDir(t *testing.T) {
 		t.Errorf("DefaultStateDir() = %q, want %q", got, want)
 	}
 }
+
+// TestParseStreamedTurnSurfacesErrorEvent verifies that a server-emitted SSE
+// "error" event (e.g. INVALID_ARGUMENT for a malformed client tool result) is
+// surfaced as a real error, instead of being silently dropped and returned as a
+// completed-but-empty turn. Dropping it made an empty directory listing look
+// like a blank "no response" turn and poisoned the resume cursor with the
+// failing interaction's id.
+func TestParseStreamedTurnSurfacesErrorEvent(t *testing.T) {
+	sse := "" +
+		"event: interaction.created\n" +
+		`data: {"interaction":{"id":"INT-1","status":"in_progress"},"event_type":"interaction.created"}` + "\n\n" +
+		"event: error\n" +
+		`data: {"event_type":"error","error":{"message":"field 'results' must be a list_value, got unset","status":"INVALID_ARGUMENT"}}` + "\n\n" +
+		"event: done\n" +
+		"data: [DONE]\n\n"
+
+	h := &AntigravityInteractionsHarness{}
+	turn, err := h.parseStreamedTurn(strings.NewReader(sse))
+	if err == nil {
+		t.Fatalf("parseStreamedTurn() = %+v, nil error; want an error for the SSE error event", turn)
+	}
+	if !strings.Contains(err.Error(), "INVALID_ARGUMENT") {
+		t.Errorf("error = %q, want it to include the server status INVALID_ARGUMENT", err)
+	}
+	if !strings.Contains(err.Error(), "must be a list_value") {
+		t.Errorf("error = %q, want it to include the server message", err)
+	}
+}
+
+func TestServerErrorMessage(t *testing.T) {
+	tests := []struct {
+		name  string
+		event map[string]any
+		want  string
+	}{
+		{
+			name:  "message and status",
+			event: map[string]any{"error": map[string]any{"message": "boom", "status": "INVALID_ARGUMENT"}},
+			want:  "boom (INVALID_ARGUMENT)",
+		},
+		{
+			name:  "message only",
+			event: map[string]any{"error": map[string]any{"message": "boom"}},
+			want:  "boom",
+		},
+		{
+			name:  "status only",
+			event: map[string]any{"error": map[string]any{"status": "UNAVAILABLE"}},
+			want:  "UNAVAILABLE",
+		},
+		{
+			name:  "no error object",
+			event: map[string]any{"event_type": "error"},
+			want:  "unknown server error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := serverErrorMessage(tt.event); got != tt.want {
+				t.Errorf("serverErrorMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
parseStreamedTurn only handled interaction.* and step.* SSE events; a server-emitted "error" event fell through the switch and was silently dropped. The turn then returned as completed-but-empty, which:

  - made a failure (e.g. INVALID_ARGUMENT for a malformed client tool result) look like a blank "no response" turn, and
  - persisted the failing interaction's id as a poisoned resume cursor.

Add an "error" case that returns a real error, plus a serverErrorMessage helper that extracts message/status from the error payload. Now a turn-level server failure aborts the turn with a descriptive error instead of being hidden.

Adds tests for the error-event path and serverErrorMessage formatting.