### PR TITLE
Replace Antigravity sidecar in-memory Agent cache with SDK-native resume

### DIFF
--- a/python/antigravity/harness_server.py
+++ b/python/antigravity/harness_server.py
@@ -21,6 +21,7 @@ import argparse
 import asyncio
 import logging
 import os
+import pathlib
 import re
 import sys
 from typing import TypedDict
@@ -135,38 +136,31 @@ def _has_credentials(config: AgentConfig | None) -> bool:
 
     return False
 
+def _existing_sdk_conv_id(save_dir: str) -> str | None:
+    # SDK persists each conversation as {save_dir}/{sdk_conv_id}.db where sdk_conv_id
+    # is SDK-picked (a hash), not our AX conversation_id. We give each AX conversation
+    # its own save_dir so at most one .db lives there; the SDK conv_id is its stem.
+    dbs = list(pathlib.Path(save_dir).glob("*.db"))
+    return dbs[0].stem if dbs else None
+
+
 class AntigravityHarnessServiceServicer(ax_pb2_grpc.HarnessServiceServicer):
     """Implements the ax.HarnessService protocol over gRPC."""
 
     def __init__(self, default_config: AgentConfig):
-        # TODO: Implement an eviction/idle-timeout policy to prevent unbounded memory growth in production.
         self._default_config = default_config
-        self._agents = {}
-        self._lock = asyncio.Lock()
 
-    async def _get_or_create_agent(self, conversation_id: str) -> Agent:
-        async with self._lock:
-            if conversation_id not in self._agents:
-                # TODO(#194): derive a per-conversation AgentConfig by layering
-                # request.start.harness_config on top of self._default_config,
-                # instead of using the default verbatim for every conversation.
-                if not self._default_config:
-                    raise ValueError("Agent config is not loaded on the server")
-                print(f"[gRPC] Creating new Agent instance for conv_id={conversation_id}")
-                agent = Agent(self._default_config)
-                await agent.__aenter__()
-                self._agents[conversation_id] = agent
-            return self._agents[conversation_id]
-
-    async def cleanup(self):
-        print("[gRPC] Cleaning up agent instances...")
-        async with self._lock:
-            for conv_id, agent in self._agents.items():
-                try:
-                    await agent.__aexit__(None, None, None)
-                except Exception as e:
-                    print(f"Error closing agent for conv_id={conv_id}: {e}")
-            self._agents.clear()
+    def _build_config_for(self, conversation_id: str) -> LocalAgentConfig:
+        # Per-AX-conv save_dir. Resume by SDK's own conv_id if a trajectory
+        # exists there. SDK auto-creates the directory.
+        # TODO(#269, #203): should be injected by the controller via
+        # harness_config; hardcoded here to mirror the Go-side
+        # antigravityinteractions.DefaultStateDir() convention.
+        save_dir = str(pathlib.Path.home() / ".ax" / "antigravity" / "conversations" / conversation_id)
+        update = {"save_dir": save_dir}
+        if sdk_conv_id := _existing_sdk_conv_id(save_dir):
+            update["conversation_id"] = sdk_conv_id
+        return self._default_config.model_copy(update=update)
 
     async def Connect(self, request_iterator, context):
         # Each HarnessRequest{start} drives one stateless turn; the stream stays
@@ -226,110 +220,108 @@ class AntigravityHarnessServiceServicer(ax_pb2_grpc.HarnessServiceServicer):
             )
             return
         try:
-            agent = await self._get_or_create_agent(request.conversation_id)
-            conversation = agent.conversation
-            
-            # The harness is stateful: the SDK's cached Agent (per conversation_id)
-            # holds the conversation history across turns within this process
-            # lifetime. The controller only sends the new turn's input; no history
-            # hydration from the client side.
-            print(f"[gRPC] Running chat query: {latest_query_text}")
-            response = await conversation.chat(latest_query_text)
-            
-            # To avoid streaming individual tokens inside TextContent messages (which is not
-            # supported by the Interactions proto/TextContent specifications), we buffer
-            # contiguous blocks of text and thought chunks, yielding them only when the 
-            # contiguous block ends or a different chunk type is received.
-            text_chunks = []
-            thought_chunks = []
-            
-            def flush_text():
-                if not text_chunks:
-                    return None
-                msg = ax_pb2.Message(
-                    role="assistant",
-                    content=content_pb2.Content(text=content_pb2.TextContent(text="".join(text_chunks)))
-                )
-                text_chunks.clear()
-                return ax_pb2.HarnessResponse(
-                    conversation_id=request.conversation_id,
-                    outputs=ax_pb2.HarnessOutputs(messages=[msg])
-                )
-                
-            def flush_thought():
-                if not thought_chunks:
-                    return None
+            per_conv_config = self._build_config_for(request.conversation_id)
+            print(f"[gRPC] Starting Agent for conv_id={request.conversation_id}, save_dir={per_conv_config.save_dir}")
+            async with Agent(per_conv_config) as agent:
+                conversation = agent.conversation
 
-                # Normalize Gemini's thinking output: collapse runs of 3+ newlines
-                # (emitted between reasoning sections) to exactly one blank line
-                # and strip trailing whitespace. Then append exactly one trailing
-                # newline so downstream displays render a blank line between the
-                # thinking block and whatever follows (next thought, tool call,
-                # or answer text). Without the trailing newline the display's
-                # transition logic emits only one newline, gluing blocks together.
-                raw_text = "".join(thought_chunks)
-                clean_text = re.sub(r'\n{3,}', '\n\n', raw_text).rstrip() + '\n'
-
-                summary = [
-                    content_pb2.ThoughtSummaryContent(text=content_pb2.TextContent(text=clean_text))
-                ]
-                thought_chunks.clear()
-                msg = ax_pb2.Message(
-                    role="model",
-                    content=content_pb2.Content(thought=content_pb2.ThoughtContent(summary=summary))
-                )
-                return ax_pb2.HarnessResponse(
-                    conversation_id=request.conversation_id,
-                    outputs=ax_pb2.HarnessOutputs(messages=[msg])
-                )
+                print(f"[gRPC] Running chat query: {latest_query_text}")
+                response = await conversation.chat(latest_query_text)
             
-            async for chunk in response.chunks:
-                if isinstance(chunk, Text):
-                    if (resp := flush_thought()):
-                        yield resp
-                    text_chunks.append(chunk.text)
-                elif isinstance(chunk, Thought):
-                    if (resp := flush_text()):
-                        yield resp
-                    thought_chunks.append(chunk.text)
-                elif isinstance(chunk, ToolCall):
-                    # Flush all pending text/thought buffers before dispatching the tool call
-                    if (resp := flush_text()):
-                        yield resp
-                    if (resp := flush_thought()):
-                        yield resp
-                    
-                    struct_args = Struct()
-                    struct_args.update(chunk.args)
-                    
-                    func_call = content_pb2.FunctionCallContent(
-                        name=str(chunk.name),
-                        arguments=struct_args
+                # To avoid streaming individual tokens inside TextContent messages (which is not
+                # supported by the Interactions proto/TextContent specifications), we buffer
+                # contiguous blocks of text and thought chunks, yielding them only when the 
+                # contiguous block ends or a different chunk type is received.
+                text_chunks = []
+                thought_chunks = []
+            
+                def flush_text():
+                    if not text_chunks:
+                        return None
+                    msg = ax_pb2.Message(
+                        role="assistant",
+                        content=content_pb2.Content(text=content_pb2.TextContent(text="".join(text_chunks)))
                     )
+                    text_chunks.clear()
+                    return ax_pb2.HarnessResponse(
+                        conversation_id=request.conversation_id,
+                        outputs=ax_pb2.HarnessOutputs(messages=[msg])
+                    )
+                
+                def flush_thought():
+                    if not thought_chunks:
+                        return None
+
+                    # Normalize Gemini's thinking output: collapse runs of 3+ newlines
+                    # (emitted between reasoning sections) to exactly one blank line
+                    # and strip trailing whitespace. Then append exactly one trailing
+                    # newline so downstream displays render a blank line between the
+                    # thinking block and whatever follows (next thought, tool call,
+                    # or answer text). Without the trailing newline the display's
+                    # transition logic emits only one newline, gluing blocks together.
+                    raw_text = "".join(thought_chunks)
+                    clean_text = re.sub(r'\n{3,}', '\n\n', raw_text).rstrip() + '\n'
+
+                    summary = [
+                        content_pb2.ThoughtSummaryContent(text=content_pb2.TextContent(text=clean_text))
+                    ]
+                    thought_chunks.clear()
                     msg = ax_pb2.Message(
                         role="model",
-                        content=content_pb2.Content(tool_call=content_pb2.ToolCallContent(
-                            id=chunk.id or "",
-                            function_call=func_call
-                        ))
+                        content=content_pb2.Content(thought=content_pb2.ThoughtContent(summary=summary))
                     )
-                    yield ax_pb2.HarnessResponse(
+                    return ax_pb2.HarnessResponse(
                         conversation_id=request.conversation_id,
                         outputs=ax_pb2.HarnessOutputs(messages=[msg])
                     )
             
-            # Flush any remaining text/thought buffers after the generator loop ends
-            if (resp := flush_text()):
-                yield resp
-            if (resp := flush_thought()):
-                yield resp
+                async for chunk in response.chunks:
+                    if isinstance(chunk, Text):
+                        if (resp := flush_thought()):
+                            yield resp
+                        text_chunks.append(chunk.text)
+                    elif isinstance(chunk, Thought):
+                        if (resp := flush_text()):
+                            yield resp
+                        thought_chunks.append(chunk.text)
+                    elif isinstance(chunk, ToolCall):
+                        # Flush all pending text/thought buffers before dispatching the tool call
+                        if (resp := flush_text()):
+                            yield resp
+                        if (resp := flush_thought()):
+                            yield resp
+                    
+                        struct_args = Struct()
+                        struct_args.update(chunk.args)
+                    
+                        func_call = content_pb2.FunctionCallContent(
+                            name=str(chunk.name),
+                            arguments=struct_args
+                        )
+                        msg = ax_pb2.Message(
+                            role="model",
+                            content=content_pb2.Content(tool_call=content_pb2.ToolCallContent(
+                                id=chunk.id or "",
+                                function_call=func_call
+                            ))
+                        )
+                        yield ax_pb2.HarnessResponse(
+                            conversation_id=request.conversation_id,
+                            outputs=ax_pb2.HarnessOutputs(messages=[msg])
+                        )
+            
+                # Flush any remaining text/thought buffers after the generator loop ends
+                if (resp := flush_text()):
+                    yield resp
+                if (resp := flush_thought()):
+                    yield resp
                         
-            # Yield completion end frame
-            yield ax_pb2.HarnessResponse(
-                conversation_id=request.conversation_id,
-                end=ax_pb2.HarnessEnd(state=ax_pb2.STATE_COMPLETED)
-            )
-            print("[gRPC] Turn completed successfully.")
+                # Yield completion end frame
+                yield ax_pb2.HarnessResponse(
+                    conversation_id=request.conversation_id,
+                    end=ax_pb2.HarnessEnd(state=ax_pb2.STATE_COMPLETED)
+                )
+                print("[gRPC] Turn completed successfully.")
             
         except Exception as e:
             logging.exception("Error inside Connect servicer execution")
@@ -359,10 +351,7 @@ async def _serve(host: str, port: int, default_config: AgentConfig):
     server.add_insecure_port(listen_addr)
     print(f"Starting gRPC harness server on {listen_addr}...")
     await server.start()
-    try:
-        await server.wait_for_termination()
-    finally:
-        await servicer.cleanup()
+    await server.wait_for_termination()
 
 def _enhance_config_from_env(config) -> None:
     skills_dir = os.environ.get("SKILLS_DIR")

--- a/python/antigravity/harness_server_test.py
+++ b/python/antigravity/harness_server_test.py
@@ -93,7 +93,13 @@ def test_grpc_connect_success(mock_config, monkeypatch):
     asyncio.run(_run())
 
 
-def test_grpc_connect_agent_reused(mock_config, monkeypatch):
+def test_grpc_connect_agent_per_turn_with_save_dir(mock_config, monkeypatch, tmp_path):
+    """Each turn spawns a fresh Agent with per-conv save_dir under
+    ~/.ax/antigravity/conversations/. Same AX conv_id -> same save_dir
+    (SDK-native resume)."""
+    import pathlib as _pathlib
+    monkeypatch.setattr(_pathlib.Path, "home", lambda: tmp_path)
+
     async def _run():
         server = grpc.aio.server()
         servicer = AntigravityHarnessServiceServicer(mock_config)
@@ -106,8 +112,6 @@ def test_grpc_connect_agent_reused(mock_config, monkeypatch):
             stub = ax_pb2_grpc.HarnessServiceStub(channel)
             
             class MockConversation:
-                def __init__(self):
-                    self._steps = []
                 async def chat(self, text):
                     class MockResponse:
                         def __init__(self):
@@ -120,62 +124,43 @@ def test_grpc_connect_agent_reused(mock_config, monkeypatch):
             agent_instances = []
             class MockAgent:
                 def __init__(self, config):
+                    self.config = config
                     self.conversation = MockConversation()
-                    self.closed = False
                     agent_instances.append(self)
                 async def __aenter__(self):
                     return self
                 async def __aexit__(self, exc_type, exc, tb):
-                    self.closed = True
+                    pass
                     
             monkeypatch.setattr("python.antigravity.harness_server.Agent", MockAgent)
-            
-            # Fire first turn for conv-1
-            req1 = ax_pb2.HarnessRequest(
-                conversation_id="conv-1",
-                harness_id="antigravity",
-                start=ax_pb2.HarnessStart(
-                    messages=[ax_pb2.Message(role="user", content=content_pb2.Content(text=content_pb2.TextContent(text="Hi")))]
+
+            async def fire(conv_id):
+                req = ax_pb2.HarnessRequest(
+                    conversation_id=conv_id,
+                    harness_id="antigravity",
+                    start=ax_pb2.HarnessStart(
+                        messages=[ax_pb2.Message(role="user",
+                            content=content_pb2.Content(text=content_pb2.TextContent(text="Hi")))]
+                    ),
                 )
-            )
-            async def req_iter1():
-                yield req1
-            async for _ in stub.Connect(req_iter1()):
-                pass
-            
-            # Fire second turn for same conv-1
-            req2 = ax_pb2.HarnessRequest(
-                conversation_id="conv-1",
-                harness_id="antigravity",
-                start=ax_pb2.HarnessStart(
-                    messages=[ax_pb2.Message(role="user", content=content_pb2.Content(text=content_pb2.TextContent(text="Hi again")))]
-                )
-            )
-            async def req_iter2():
-                yield req2
-            async for _ in stub.Connect(req_iter2()):
-                pass
-                
-            # Fire third turn for a different conv-2
-            req3 = ax_pb2.HarnessRequest(
-                conversation_id="conv-2",
-                harness_id="antigravity",
-                start=ax_pb2.HarnessStart(
-                    messages=[ax_pb2.Message(role="user", content=content_pb2.Content(text=content_pb2.TextContent(text="New conv")))]
-                )
-            )
-            async def req_iter3():
-                yield req3
-            async for _ in stub.Connect(req_iter3()):
-                pass
-                
-            # Verify only 2 agents were instantiated (reused the first one)
-            assert len(agent_instances) == 2
-            
-            # Verify cleanup closes all agents
-            await servicer.cleanup()
-            assert all(a.closed for a in agent_instances)
-            
+                async def req_iter():
+                    yield req
+                async for _ in stub.Connect(req_iter()):
+                    pass
+
+            await fire("conv-1")
+            await fire("conv-1")
+            await fire("conv-2")
+
+            assert len(agent_instances) == 3
+            save_dirs = [a.config.save_dir for a in agent_instances]
+            assert save_dirs[0] == save_dirs[1]
+            assert save_dirs[0] != save_dirs[2]
+            assert save_dirs[0].endswith("/conv-1")
+            assert save_dirs[2].endswith("/conv-2")
+            # conversation_id only passed when trajectory exists (not in these mocked runs).
+            assert [a.config.conversation_id for a in agent_instances] == [None, None, None]
+
         await server.stop(0)
 
     asyncio.run(_run())


### PR DESCRIPTION
## Problem

Antigravity harness caches Agent per conversation in memory. Substrate snapshot won't include memory, and local server restarts when a conversation resumes. This setup doesn't work for conversation
resumption.

## Assumption 

1. Single writer so no lock needed 

## Fix

1. Delete the cache. 
3. Use `LocalAgentConfig`'s native `(conversation_id,save_dir)` — SDK persists trajectory state to
`{save_dir}/{sdk_conv_id}.db`. 
4. **Note:** Each AX conversation gets its own directory under `~/.ax/antigravity/conversations/{ax_conv_id}/`; on
subsequent turns we discover the SDK's hash-id from the `.db` filename
and pass it back to resume.

**This is because SDK's `conversation_id` is resume-only — passing a non-existent id errors.** Hence discover-then-pass, not pass-always. 

Alternatively we can store the {AX convs_id : AGY convs_id} separately but this simplify the overall logic and setup 

## Next

`save_dir` is hardcoded here. Should be injected by controller via `harness_config` — see #269, #203. TODO in code.

## Tasks

- [x] Test local (`ax exec --conversation <id>` across fresh sidecar
      processes → resume works, isolation works)
- [x] Test substrate