### PR TITLE
fix(harness): wire --state-dir for the Antigravity SDK harness on substrate

### DIFF
--- a/cmd/ax/harness.go
+++ b/cmd/ax/harness.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/google/ax/internal/config"
+	"github.com/google/ax/internal/harness/antigravity"
 	"github.com/google/ax/internal/harness/antigravityinteractions"
 	"github.com/google/ax/internal/pythonsidecar"
 	"github.com/spf13/cobra"
@@ -102,11 +103,17 @@ func runAntigravityHarness(cmd *cobra.Command) error {
 		return err
 	}
 
+	stateDir, err := antigravity.DefaultStateDir()
+	if err != nil {
+		return fmt.Errorf("failed to resolve antigravity state dir: %w", err)
+	}
+
 	cfg := pythonsidecar.Config{
 		Module: "python.antigravity.harness_server",
 		Args: []string{
 			"--host", harnessHost,
 			"--port", strconv.Itoa(harnessPort),
+			"--state-dir", stateDir,
 		},
 		Stdout:    os.Stdout,
 		Stderr:    os.Stderr,


### PR DESCRIPTION
## Summary

- Derive the trajectory dir via `antigravity.DefaultStateDir()` and pass it to the sidecar as `--state-dir`, mirroring the local path (`antigravity.New`) and the interactions harness  
- 
## Testing
- `go build`, `go vet`, `go test ./...` pass.
- No new unit test: the resolved path comes from `antigravity.DefaultStateDir()`, which is already covered by `TestDefaultStateDir` in `internal/harness/antigravity/antigravity_test.go`. This change only wires that existing, tested value into the sidecar args.

Fixes #321