### PR TITLE
antigravity: bump google-antigravity 0.1.5 -> 0.1.7

### DIFF
--- a/python/antigravity/requirements.txt
+++ b/python/antigravity/requirements.txt
@@ -1,4 +1,4 @@
 # Runtime dependencies for the antigravity HarnessService server
 # (python/antigravity/harness_server.py).
-google-antigravity==0.1.5
+google-antigravity==0.1.7
 grpcio-health-checking==1.81.0


### PR DESCRIPTION
## Summary
- Bump `google-antigravity` 0.1.5 → 0.1.7 in the sidecar requirements.
- 0.1.7 reads GenAI credential env vars natively; this is the prerequisite for removing the sidecar's `_vertex_kwargs_from_env` override (follow-up PR).
- Behavior unchanged here: with the override still present, its explicit kwargs take precedence, so the result is identical.

## Validation
- Sidecar test suite: 32/32 pass against 0.1.7.
- Exercised real 0.1.7 locally: bare `LocalAgentConfig()` + env vars routes to Vertex with project/location hydrated (also via `USE_ENTERPRISE`); AI Studio path unchanged.
- Reviewed the 0.1.5→0.1.7 SDK diff scoped to ax's surface (`Agent`, `LocalAgentConfig`, `types.{Text,Thought,ToolCall}`, `conversation.chat`) — no breaking changes; new `LocalAgentConfig` params are additive.

Part of #325.

Next:
- clean up overrides that no longer needed with 0.1.7 