### PR TITLE
antigravity: remove _resolve_localhost /etc/hosts hack

### DIFF
--- a/python/antigravity/harness_server.py
+++ b/python/antigravity/harness_server.py
@@ -450,28 +450,6 @@ def _enhance_config_from_env(config) -> None:
             config.skills_paths.append(skills_dir)
 
 
-def _resolve_localhost():
-    """Ensure `localhost` resolves to 127.0.0.1.
-
-    Substrate actors run under gVisor with no runtime-injected /etc/hosts.
-    The antigravity SDK dials localharness at ws://localhost:<port>/
-    and Python's resolver needs `localhost` in /etc/hosts.
-    """
-    try:
-        try:
-            with open("/etc/hosts", "r") as f:
-                if "localhost" in f.read():
-                    return
-        except FileNotFoundError:
-            pass
-        with open("/etc/hosts", "a") as f:
-            f.write("127.0.0.1\tlocalhost\n")
-    except OSError as e:
-        print(
-            f"WARNING: could not ensure localhost in /etc/hosts: {e}", file=sys.stderr
-        )
-
-
 def main():
     parser = argparse.ArgumentParser(description="Antigravity gRPC Harness Server")
     parser.add_argument(
@@ -500,10 +478,6 @@ def main():
         # Single startup-config exit point.
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
-
-    # This is a hack, on Agent Substrate /etc/hosts end up not
-    # having this entry even if it's the OCI image.
-    _resolve_localhost()
 
     asyncio.run(
         _serve(


### PR DESCRIPTION
## Summary
- Remove the `_resolve_localhost()` hack that patched `/etc/hosts` so `localhost` resolved under substrate/gVisor.
- Obsolete as of `google-antigravity` 0.1.7: the SDK's `_connect_websocket` now retries both `localhost` and `127.0.0.1` when dialing localharness (`local_connection.py:993`), so the fallback is handled upstream.

## Testing
- [x] Local: sidecar suite 32/32; booted the real gRPC server and confirmed it serves health without the hack.
- [x] Substrate: verified on Agent Substrate (GKE `lhuan-substrate`, gVisor, no injected `/etc/hosts`). Deployed the antigravity harness image built from this branch with Vertex via Workload Identity (no API key in image). Real end-to-end turn returned a model response (`PR328_OK`); suspend/restore (`RESTORE_OK`) and cold restore after deleting all worker pods (`COLD_OK`) both succeeded. Zero `Failed to connect/initialize WebSocket` or localhost-resolution errors across the run. Confirmed SDK 0.1.7 fallback in the image: `local_connection.py` `for host in ("localhost", "127.0.0.1")`. SDK 0.1.7, substrate `v0.0.0-20260706222328-3cb7433bd8a8`.

Part of #325.
