### PR TITLE
chore: remove stale docs, gitignore, and Makefile entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,8 @@
 bin/*
 eventlog/*
 /ax
-local_agent
-remote_agent
 *.log
 ax-bin
-google-cloud-cli-darwin-arm.tar.gz
-google-cloud-sdk/
-test-sandbox-config.yaml
-sandbox-router
-examples/sandbox_agent/cloudbuild.yaml
-tasklog/*
 python/__pycache__
 python/proto/__pycache__
-/axepp
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,12 +60,6 @@ make proto
 make test
 ```
 
-### Run remote agent
-
-```bash
-make run-remote
-```
-
 ### Install the ax CLI
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build proto test test-python clean install
+.PHONY: all build proto test test-python clean install deps clean-logs
 
 # Build all binaries
 all: proto build


### PR DESCRIPTION
## Summary
Housekeeping for references to code/targets that no longer exist.

- **CONTRIBUTING.md**: drop the `make run-remote` section — no such Makefile target.
- **.gitignore**: remove orphaned entries with no matching files (`local_agent`, `remote_agent`, `sandbox-router`, `examples/sandbox_agent/cloudbuild.yaml`, `tasklog/*`, `/axepp`, `google-cloud-sdk/`, `google-cloud-cli-darwin-arm.tar.gz`, `test-sandbox-config.yaml`).
- **Makefile**: add missing `deps` and `clean-logs` to `.PHONY`.

No functional/build changes; `go build ./...` passes.